### PR TITLE
[FEATURE] Add page: Resources for Developers

### DIFF
--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -74,6 +74,7 @@ Tip of the day - did you know?
    typo3cms/SystemExtensions/Index
    typo3cms/GuidesAndTutorials/Index
    typo3cms/References/Index
+   typo3cms/Developers/Index
    Snippets, Tips and Howtos  ➜  <https://docs.typo3.org/typo3cms/Snippets/>
    typo3cms/Teams/Index
    Tell me something about X  ➜  <https://docs.typo3.org/typo3cms/TellMeSomethingAbout/>

--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -74,7 +74,8 @@ Tip of the day - did you know?
    typo3cms/SystemExtensions/Index
    typo3cms/GuidesAndTutorials/Index
    typo3cms/References/Index
-   typo3cms/Developers/Index
+   typo3cms/TargetGroups/Integrators
+   typo3cms/TargetGroups/Developers
    Snippets, Tips and Howtos  ➜  <https://docs.typo3.org/typo3cms/Snippets/>
    typo3cms/Teams/Index
    Tell me something about X  ➜  <https://docs.typo3.org/typo3cms/TellMeSomethingAbout/>

--- a/Documentation/typo3cms/Developers/Index.rst
+++ b/Documentation/typo3cms/Developers/Index.rst
@@ -1,0 +1,196 @@
+.. _resources-developers:
+
+
+.. ------------------------------------------------------------
+.. todos:
+.. Look through the following resources if they are up-to-date
+.. and can be used or update / migrate / delete them
+..
+.. - Wiki: https://wiki.typo3.org/Extension_Developers_Guide
+.. - Wiki: https://wiki.typo3.org/Extension_Development
+.. -------------------------------------------------------------
+
+========================
+Resources for Developers
+========================
+
+This page contains some resources for TYPO3 developers including information
+about **extension development**, **site package extension development** and
+**core development**.
+
+It contains links to official TYPO3 docs. However, if the official docs are
+outdated and there are newer resources available elsewhere (e.g. on blogs),
+a link to these is supplied.
+
+You can assume that whatever starts with
+`http://docs.typo3.org/typo3cms` and is linked from this page is official
+TYPO3 documentation.
+
+.. _resources-developers-extension:
+
+Extension Development
+=====================
+
+.. _resources-developers-extension-getting-started:
+
+Getting started
+---------------
+
+For getting started with TYPO3 development, please ask for up-to-date
+resources in the Slack channel **#typo3-cms** or **#typo3-documentation**
+(register for Slack here: https://my.typo3.org/)
+
+It is difficult to give general information here because it depends on the
+TYPO3 version you will be using and what you plan to do.
+
+.. _resources-developers-extension-getting-started-extbase-fluid:
+
+Extbase / Fluid
+~~~~~~~~~~~~~~~
+
+.. todo: question: can these resources still be recommended for TYPO3 8?
+.. should additional information be added here?
+
+For a walkthrough guide on Extension Development with Extbase / Fluid
+you can look at:
+
+* :ref:`Developing TYPO3 Extensions with Extbase and Fluid <t3extbasebook:start>`
+  (Official TYPO3 docs, a translation of the German book by Kurfürst and  Rau, updated
+  by the community)
+* The (hardcover) book: Michael Schams and Patrick Lobacher: The TYPO3 Extbase Book
+  (http://extbase-book.org) The latest version is for TYPO3 7.6.
+
+.. todo: insert general informational text about current status of Extbase
+
+
+Fluid
+~~~~~
+
+Note that Fluid is now maintained outside of the TYPO3 core. The core itself
+contains an extension named EXT:fluid with some TYPO3-specific functionality and
+there is a composer dependency on typo3fluid/fluid, which is the main Fluid
+core. You can find it in your installation under :file:`vendor/typo3fluid/fluid`
+
+For this reason, main Fluid documentation is found outside of docs.typo3.org.
+
+Go to the main `Fluid page on Github <https://github.com/TYPO3/Fluid>`__
+for a list of resources.
+
+.. _resources-developers-extension-getting-started-site-package:
+
+Develop a site package
+~~~~~~~~~~~~~~~~~~~~~~
+
+For up-to-date tutorials on developing a "Site Package" (aka template) Extension,
+please see these Videos in the TYPO3 channel on YouTube:
+
+* `Tutorial - Site Packages - Part 1 <https://www.youtube.com/watch?v=HtBmim7pc0o>`__
+* `Tutorial - Site Packages - Part 2 <https://www.youtube.com/watch?v=deSMVfCSCXY>`__
+
+There are also 2 manuals currently in draft that may be useful to you:
+
+* DRAFT: `Site Package Tutorial
+  <https://docs.typo3.org/typo3cms/drafts/github/TYPO3-Documentation/SitePackageTutorial/>`__
+* DRAFT: `Templating with FLUIDTEMPLATE
+  <https://docs.typo3.org/typo3cms/drafts/github/TYPO3-Documentation/TYPO3CMS-Tutorial-TemplatingWithFluidtemplate/>`__
+
+.. _resources-developers-extension-general:
+
+General Resources
+-----------------
+
+.. _resources-developers-extension-general-references:
+
+Reference Guides in the official TYPO3 documentation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Look at the official list of references: :ref:`List of TYPO3 references<references>`
+
+For developing you will be interested in all the manuals listed there, especially the
+:ref:`TYPO3 Core API <t3coreapi:start>`.
+
+Additionally, see the references for TYPO3 Fluid ViewHelpers.
+
+* :ref:`Reference for Fluid ViewHelpers <t3extbasebook:viewhelpers>`
+
+
+.. _resources-developers-extension-general-videos:
+
+YouTube Videos
+~~~~~~~~~~~~~~
+
+* `TYPO3 YouTube Channel <https://www.youtube.com/channel/UCwpl8LY9Tr3PB26Kk2FYW_w>`__
+
+Unofficial Resources
+~~~~~~~~~~~~~~~~~~~~
+
+These are not "official" TYPO3 resources, but they have been reported to be very
+useful and sometimes provide more up-to-date information than the official docs.
+
+Blogs:
+
+.. note to editors: please only add blogs specifically dedicated to programming for TYPO3 or
+.. link to specific blog articles about programming for TYPO3
+
+* Daniel Goerz: `Usetypo3 <https://usetypo3.com/>`__  This might be the best resource for getting
+  started, for example look at `Good practices in Extensions <https://usetypo3.com/good-practices-in-extensions.html>`__,
+  and `24 Tips & Tricks for Fluid <https://usetypo3.com/24-fluid-tips.html>`__
+  Marcus Schwemer: `TYPO3 WORX <https://typo3worx.eu>`__
+* Andreas Fernandez (member of TYPO3 core team): `SCRIPTING-BASE <https://scripting-base.de/blog.html>`__
+  provides some in-depth information for example about Ajax and RequireJS and also very useful
+  instructions for :ref:`migrating-extensions`.
+* Helmut Hummel (member of TYPO3 core team): `doc_core_insight <https://usetypo3.com/>`__ Helmut's
+  resources are especially useful, if you are looking at information about composer and TYPO3,
+  executing commands from the console (typo3_console), caching, autoloading etc. It is often in-depth
+  information that helps to understand things, not always suitable for beginners.
+
+
+Specific Resources
+------------------
+
+.. _migrating-extensions:
+
+Migrating extensions
+~~~~~~~~~~~~~~~~~~~~
+
+You may be maintaining a TYPO3 installation and need to update to the
+next major TYPO3 version. TYPO3 already takes care of everything you
+need to do very nicely in the Upgrade Wizard. Third party extensions
+can also be updated easily.
+
+If you have developed some extensions yourself, you will want to make
+sure, that they will be ready for the next major TYPO3 version *before*
+you update!
+
+For this, the deprecation log and :ref:`Extension Scanner <extension-scanner>`
+(Extension Scanner since TYPO3 version 9) is very valuable.
+
+Additionally, look at these resources:
+
+* Check the `Official Changelogs <https://docs.typo3.org/typo3cms/extensions/core/latest/>`__
+  for "Breaking changes" for your target version. Also checkout the "Changes for Developers"
+  section in the `What's new slides <https://typo3.org/help/documentation/whats-new/>`__ for
+  the target version
+* `Usetypo3: Updating TYPO3 Projects <https://usetypo3.com/upgrading-projects.html>`__
+* For migrating TCA: `SCRIPTING-BASE: Cleaning the hood: TCA <https://scripting-base.de/blog/cleaning-the-hood-tca.html>`__
+
+If your extensions are quite old, also look at:
+
+* `ClassAliasMap.php
+  <https://git.typo3.org/Packages/TYPO3.CMS.git/blob/refs/heads/TYPO3_6-2:/typo3/sysext/core/Migrations/Code/ClassAliasMap.php>`__
+  for a mapping of old and new class names
+* :ref:`namespaces <t3coreapi:namespaces>`
+
+
+
+
+TYPO3 Core development
+======================
+
+* If you want to get started with core development, see
+  :ref:`TYPO3 Contribution Guide <t3contribute:start>` for a walkthrough
+  through the toolchain
+* Look at the official :ref:`Core API<t3coreapi:start>` for introduction to basic concepts
+
+
+

--- a/Documentation/typo3cms/Developers/Index.rst
+++ b/Documentation/typo3cms/Developers/Index.rst
@@ -78,7 +78,7 @@ For this reason, main Fluid documentation is found outside of docs.typo3.org.
 Go to the main `Fluid page on Github <https://github.com/TYPO3/Fluid>`__
 for a list of resources.
 
-.. _resources-developers-extension-getting-started-site-package:
+.. _resources-developers-site-package:
 
 Develop a site package
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/Documentation/typo3cms/Developers/Index.rst
+++ b/Documentation/typo3cms/Developers/Index.rst
@@ -38,7 +38,7 @@ Getting started
 
 For getting started with TYPO3 development, please ask for up-to-date
 resources in the Slack channel **#typo3-cms** or **#typo3-documentation**
-(register for Slack here: https://my.typo3.org/)
+(register for Slack here: https://my.typo3.org/index.php?id=35)
 
 It is difficult to give general information here because it depends on the
 TYPO3 version you will be using and what you plan to do.
@@ -55,7 +55,7 @@ For a walkthrough guide on Extension Development with Extbase / Fluid
 you can look at:
 
 * :ref:`Developing TYPO3 Extensions with Extbase and Fluid <t3extbasebook:start>`
-  (Official TYPO3 docs, a translation of the German book by Kurfürst and  Rau, updated
+  (Official TYPO3 docs, a translation of the German book by Kurfürst and Rau, updated
   by the community)
 * The (hardcover) book: Michael Schams and Patrick Lobacher: The TYPO3 Extbase Book
   (http://extbase-book.org) The latest version is for TYPO3 7.6.
@@ -68,8 +68,10 @@ Fluid
 
 Note that Fluid is now maintained outside of the TYPO3 core. The core itself
 contains an extension named EXT:fluid with some TYPO3-specific functionality and
-there is a composer dependency on typo3fluid/fluid, which is the main Fluid
-core. You can find it in your installation under :file:`vendor/typo3fluid/fluid`
+there is a composer dependency on
+`typo3fluid/fluid <https://packagist.org/packages/typo3fluid/fluid>`__,
+which is the main Fluid core. You can find it in your installation
+under :file:`vendor/typo3fluid/fluid`
 
 For this reason, main Fluid documentation is found outside of docs.typo3.org.
 
@@ -168,9 +170,10 @@ For this, the deprecation log and :ref:`Extension Scanner <extension-scanner>`
 Additionally, look at these resources:
 
 * Check the `Official Changelogs <https://docs.typo3.org/typo3cms/extensions/core/latest/>`__
-  for "Breaking changes" for your target version. Also checkout the "Changes for Developers"
-  section in the `What's new slides <https://typo3.org/help/documentation/whats-new/>`__ for
-  the target version
+  for "Breaking changes" for your target version. Also check out the
+  "Changes for Developers" section in the
+  `What's new slides <https://typo3.org/help/documentation/whats-new/>`__
+  for the target version
 * `Usetypo3: Updating TYPO3 Projects <https://usetypo3.com/upgrading-projects.html>`__
 * For migrating TCA: `SCRIPTING-BASE: Cleaning the hood: TCA <https://scripting-base.de/blog/cleaning-the-hood-tca.html>`__
 

--- a/Documentation/typo3cms/GuidesAndTutorials/Index.rst
+++ b/Documentation/typo3cms/GuidesAndTutorials/Index.rst
@@ -147,15 +147,9 @@ represents a logical progression in the knowledge of the product.
    :Shortcut:     t3templating
    :Comment:      Marker based tutorial. Outdated and not recommended. Use Fluid. See :ref:`dev-hints-site-package` on the bottom of this page.
 
+.. _guides-further-resources-developers:
+
 Further resources for TYPO3 developers
 ======================================
 
-.. _dev-hints-site-package:
-
-Develop a Site Package Extension
---------------------------------
-
-* For up-to-date information on developing a "Site Package" (aka template, ...) Extension, please see these Videos in the TYPO3 channel on YouTube:
-
-   * `Tutorial - Site Packages - Part 1 <https://www.youtube.com/watch?v=HtBmim7pc0o>`__
-   * `Tutorial - Site Packages - Part 2 <https://www.youtube.com/watch?v=deSMVfCSCXY>`__
+See page :ref:`Resources for Developers <resources-developers-site-package>`

--- a/Documentation/typo3cms/GuidesAndTutorials/Index.rst
+++ b/Documentation/typo3cms/GuidesAndTutorials/Index.rst
@@ -145,11 +145,6 @@ represents a logical progression in the knowledge of the product.
  - :Manual:       :ref:`t3templating:start`
    :Type:         Tutorial
    :Shortcut:     t3templating
-   :Comment:      Marker based tutorial. Outdated and not recommended. Use Fluid. See :ref:`dev-hints-site-package` on the bottom of this page.
+   :Comment:      Marker based tutorial. Outdated and not recommended. Use Fluid. See :ref:`resources-site-package` for better resources
 
-.. _guides-further-resources-developers:
 
-Further resources for TYPO3 developers
-======================================
-
-See page :ref:`Resources for Developers <resources-developers-site-package>`

--- a/Documentation/typo3cms/TargetGroups/Developers.rst
+++ b/Documentation/typo3cms/TargetGroups/Developers.rst
@@ -1,5 +1,4 @@
-.. _resources-developers:
-
+.. include:: ../../Includes.txt
 
 .. ------------------------------------------------------------
 .. todos:
@@ -9,6 +8,8 @@
 .. - Wiki: https://wiki.typo3.org/Extension_Developers_Guide
 .. - Wiki: https://wiki.typo3.org/Extension_Development
 .. -------------------------------------------------------------
+
+.. _resources-developers:
 
 ========================
 Resources for Developers
@@ -78,23 +79,7 @@ For this reason, main Fluid documentation is found outside of docs.typo3.org.
 Go to the main `Fluid page on Github <https://github.com/TYPO3/Fluid>`__
 for a list of resources.
 
-.. _resources-developers-site-package:
 
-Develop a site package
-~~~~~~~~~~~~~~~~~~~~~~
-
-For up-to-date tutorials on developing a "Site Package" (aka template) Extension,
-please see these Videos in the TYPO3 channel on YouTube:
-
-* `Tutorial - Site Packages - Part 1 <https://www.youtube.com/watch?v=HtBmim7pc0o>`__
-* `Tutorial - Site Packages - Part 2 <https://www.youtube.com/watch?v=deSMVfCSCXY>`__
-
-There are also 2 manuals currently in draft that may be useful to you:
-
-* DRAFT: `Site Package Tutorial
-  <https://docs.typo3.org/typo3cms/drafts/github/TYPO3-Documentation/SitePackageTutorial/>`__
-* DRAFT: `Templating with FLUIDTEMPLATE
-  <https://docs.typo3.org/typo3cms/drafts/github/TYPO3-Documentation/TYPO3CMS-Tutorial-TemplatingWithFluidtemplate/>`__
 
 .. _resources-developers-extension-general:
 

--- a/Documentation/typo3cms/TargetGroups/Developers.rst
+++ b/Documentation/typo3cms/TargetGroups/Developers.rst
@@ -16,7 +16,7 @@ Resources for Developers
 ========================
 
 This page contains some resources for TYPO3 developers including information
-about **extension development**, **site package extension development** and
+about **extension development** and
 **core development**.
 
 It contains links to official TYPO3 docs. However, if the official docs are

--- a/Documentation/typo3cms/TargetGroups/Integrators.rst
+++ b/Documentation/typo3cms/TargetGroups/Integrators.rst
@@ -1,0 +1,23 @@
+.. include:: ../../Includes.txt
+
+=========================
+Resources for Integrators
+=========================
+
+.. _resources-site-package:
+
+Develop a site package
+~~~~~~~~~~~~~~~~~~~~~~
+
+For up-to-date tutorials on creating a "Site Package" (aka template) Extension,
+please see these Videos in the TYPO3 channel on YouTube:
+
+* `Tutorial - Site Packages - Part 1 <https://www.youtube.com/watch?v=HtBmim7pc0o>`__
+* `Tutorial - Site Packages - Part 2 <https://www.youtube.com/watch?v=deSMVfCSCXY>`__
+
+There is also a manual currently in draft that may be useful to you:
+
+* DRAFT: `Site Package Tutorial
+  <https://docs.typo3.org/typo3cms/drafts/github/TYPO3-Documentation/SitePackageTutorial/>`__
+.. * DRAFT: `Templating with FLUIDTEMPLATE
+..  <https://docs.typo3.org/typo3cms/drafts/github/TYPO3-Documentation/TYPO3CMS-Tutorial-TemplatingWithFluidtemplate/>`__


### PR DESCRIPTION
Currently, the lists on the homepage are missing some up-to-date resources for developers and additional hints, especially for people getting started with developing for TYPO3. This PR attempts to remedy the situation, by providing some basic information and comments on existing resources as well as filling in the missing peaces by supplying links to resources elsewhere, where official TYPO3 documentation may not be up-to-date.