### PR TITLE
Reorder documentation menu add changelog button

### DIFF
--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -51,7 +51,7 @@ Latest documentation news
 
 
 
-Tip of the day - did you know?
+Tips - did you know?
 ------------------------------
 
 .. sidebar:: Quickstart extension documentation
@@ -59,11 +59,11 @@ Tip of the day - did you know?
    You are an extension author and want to add documentation?
    Please read :ref:`tip-of-the-day-2016-12-29`
 
--  2017-02-13 :ref:`tip-of-the-day-2017-02-13`
--  2016-12-29 :ref:`tip-of-the-day-2016-12-29`
--  2016-10-08 :ref:`tip-of-the-day-2016-10-08`
--  2016-09-11 :ref:`tip-of-the-day-2016-09-11`
--  Find all: :ref:`Tip-of-the-day`
+-  :ref:`tip-of-the-day-2017-02-13`
+-  :ref:`tip-of-the-day-2016-12-29`
+-  :ref:`tip-of-the-day-2016-10-08`
+-  :ref:`tip-of-the-day-2016-09-11`
+-  :ref:`All the tips<Tip-of-the-day>`
 
 
 

--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -14,14 +14,14 @@ Welcome to the official TYPO3 Documentation
 Common quick links
 ------------------
 
-.. rst-class:: horizbuttons-primary-xxl
+.. rst-class:: horizbuttons-primary-m
 
-- :ref:`TYPO3 Core APIs <t3coreapi:Start>`
+- :ref:`Core APIs <t3coreapi:Start>`
+- `Core ChangeLog <https://docs.typo3.org/typo3cms/extensions/core/latest/>`__
+- :ref:`Security Guide <t3security:Start>`
 - :ref:`TCA Reference <t3tca:Start>`
-- :ref:`TypoScript Reference <t3tsref:Start>`
 - :ref:`TSconfig Reference <t3tsconfig:Start>`
-- :ref:`TYPO3 Security Guide <t3security:Start>`
-- :ref:`TYPO3 Core ChangeLog <https://docs.typo3.org/typo3cms/extensions/core/latest/>`
+- :ref:`TypoScript Reference <t3tsref:Start>`
 
 
 

--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -21,6 +21,7 @@ Common quick links
 - :ref:`TypoScript Reference <t3tsref:Start>`
 - :ref:`TSconfig Reference <t3tsconfig:Start>`
 - :ref:`TYPO3 Security Guide <t3security:Start>`
+- :ref:`TYPO3 Core ChangeLog <https://docs.typo3.org/typo3cms/extensions/core/latest/>`
 
 
 
@@ -69,12 +70,12 @@ Tip of the day - did you know?
 .. toctree::
    :hidden:
 
-   typo3cms/CheatSheets/Index
-   typo3cms/extensions/Index
-   typo3cms/SystemExtensions/Index
    typo3cms/GuidesAndTutorials/Index
    typo3cms/References/Index
+   typo3cms/SystemExtensions/Index
    Snippets, Tips and Howtos  ➜  <https://docs.typo3.org/typo3cms/Snippets/>
-   typo3cms/Teams/Index
+   typo3cms/CheatSheets/Index
+   typo3cms/extensions/Index
    Tell me something about X  ➜  <https://docs.typo3.org/typo3cms/TellMeSomethingAbout/>
    About
+   typo3cms/Teams/Index

--- a/Documentation/typo3cms/extensions/Index.rst
+++ b/Documentation/typo3cms/extensions/Index.rst
@@ -14,9 +14,7 @@ Third party (TER) extensions
 Here you can find documentation for third party extensions
 available through :ref:`TYPO3 Extension Repository (TER) <https://extensions.typo3.org/>`.
 
-If you're looking for documentation of the extensions shipped with TYPO3 Core, go to the `system extensions section`__. 
-
-__ typo3cms/SystemExtensions/
+If you're looking for documentation of the extensions shipped with TYPO3 Core, go to the :ref:`system extensions section <System-Extensions>`.
 
 The server tries to keep a `json file about extensions`__
 up to date. Moreover there's a manually maintained

--- a/Documentation/typo3cms/extensions/Index.rst
+++ b/Documentation/typo3cms/extensions/Index.rst
@@ -1,8 +1,8 @@
 :template: extensions.html
 
-========================
-Extensions
-========================
+============================
+Third party (TER) extensions
+============================
 
 .. ATTENTION:
    Be careful with this special folder /typo3cms/extensions !!!
@@ -11,12 +11,21 @@ Extensions
 .. First
    You may add normal rst content here.
 
+Here you can find documentation for third party extensions
+available through :ref:`TYPO3 Extension Repository (TER) <https://extensions.typo3.org/>`.
+
+If you're looking for documentation of the extensions shipped with TYPO3 Core, go to the `system extensions section`. 
+
+__ typo3cms/SystemExtensions/
+
 The server tries to keep a `json file about extensions`__
 up to date. Moreover there's a manually maintained
 `json file about system extensions`__.
 
 __ extensions.js
 __ systemextensions.js
+
+
 
 **Use the following form to search by extension keys.**
 

--- a/Documentation/typo3cms/extensions/Index.rst
+++ b/Documentation/typo3cms/extensions/Index.rst
@@ -14,7 +14,7 @@ Third party (TER) extensions
 Here you can find documentation for third party extensions
 available through :ref:`TYPO3 Extension Repository (TER) <https://extensions.typo3.org/>`.
 
-If you're looking for documentation of the extensions shipped with TYPO3 Core, go to the `system extensions section`. 
+If you're looking for documentation of the extensions shipped with TYPO3 Core, go to the `system extensions section`__. 
 
 __ typo3cms/SystemExtensions/
 


### PR DESCRIPTION
The documentation menu has now more logical order (the most important documents are on top)
The button for the TYPO3 Core changelog has been added 