### PR TITLE
Update news entry about TYPO3 explained

### DIFF
--- a/Documentation/News/2018/Index.rst
+++ b/Documentation/News/2018/Index.rst
@@ -80,7 +80,7 @@ on the list:
   merge them. At the moment it seems we're able to cope with it. Keep up the good work and use
   the "Edit me on github" button in the top right corner, if you spot issues: Go ahead and improve!
 
-* If you are interested in helping with TYPO3 documentation, you are welcome to join the growing list
+* If you are interested in helping with TYPO3 documentation, you are invited to join the growing list
   of contributors. See :ref:`h2document:docs-contribute` for more information.
 
 .. _news-2018-06-13:

--- a/Documentation/News/2018/Index.rst
+++ b/Documentation/News/2018/Index.rst
@@ -78,8 +78,10 @@ on the list:
 * We see an increasing number of persons changing details of the documentation all over the place, too
   many to mention in person. This is great! We try our best to review pull requests in time and
   merge them. At the moment it seems we're able to cope with it. Keep up the good work and use
-  the "Edit me on github" button in the top right corner much if you spot issues: Go ahead and improve!
+  the "Edit me on github" button in the top right corner, if you spot issues: Go ahead and improve!
 
+* If you are interested in helping with TYPO3 documentation, you are welcome to join the growing list
+  of contributors. See :ref:`h2document:docs-contribute` for more information.
 
 .. _news-2018-06-13:
 .. rst-class:: panel panel-default


### PR DESCRIPTION
The news entry mentions contributions and motivates people to contribute to the docs. The reader should be pointed to information about how to contribute to the docs. This commit message adds a link to this information.