### PR TITLE
Use "system extension" instead of "core extension"

### DIFF
--- a/Documentation/typo3cms/SystemExtensions/Index.rst
+++ b/Documentation/typo3cms/SystemExtensions/Index.rst
@@ -2,9 +2,9 @@
 
 .. _System-Extensions:
 
-===============
-Core Extensions
-===============
+=================
+System Extensions
+=================
 
 Documentation of extensions managed within the core repository directly
 and maintained by the core team and core contributors are called


### PR DESCRIPTION
We decided to use "system extension" in #typo3-documentation channel.
Also, this is what is being used in the description and in most of
the documenation.