### PR TITLE
Change order in main menu

### DIFF
--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -66,17 +66,25 @@ Tips - did you know?
 -  :ref:`All the tips<Tip-of-the-day>`
 
 
+.. the menu (now) has the following order:
+   1. Official Documentation
+   2. Community Documentation
+   3. About documentation: "About"
+   4. Additional information, like Teams: typo3cms/Teams
+
+.. todo: Define what is "official" documentation, what is "community"
+   documentation, e.g. surf, snippets, cheat sheets etc.
 
 .. toctree::
    :hidden:
 
    typo3cms/GuidesAndTutorials/Index
    typo3cms/References/Index
-   typo3cms/SystemExtensions/Index
-   Snippets, Tips and Howtos  ➜  <https://docs.typo3.org/typo3cms/Snippets/>
-   typo3cms/CheatSheets/Index
-   typo3cms/extensions/Index
    Tell Me Something About Topic X  ➜  <https://docs.typo3.org/typo3cms/TellMeSomethingAbout/>
+   typo3cms/SystemExtensions/Index
+   typo3cms/extensions/Index
+   Surf for Deployment  ➜  <https://docs.typo3.org/surf/>
+   typo3cms/CheatSheets/Index
+   Snippets  ➜  <https://docs.typo3.org/typo3cms/Snippets/>
    About
    typo3cms/Teams/Index
-   Surf for Deployment  ➜  <https://docs.typo3.org/surf/>


### PR DESCRIPTION
The proposed order has been added as a comment:

1. Official documentation
2. Community documentation
3. About documenation
4. Teams

It is a little difficult to determine, what is community and what is
"official", but we propose to assume snippets, cheat sheets and external
extensions as "community" documentation.

Additionally, the snippets only contain snippets, so we remove "Tipps
and Howto" in menu title because that is misleading and not helpful.