### PR TITLE
Move tip for rendering extension documentation

### DIFF
--- a/Documentation/News/2018/Index.rst
+++ b/Documentation/News/2018/Index.rst
@@ -304,28 +304,7 @@ First possible dates are in the range of April 12-16, 2018.
 HELP: My extension documentation was rendered with the OLD layout!
 ------------------------------------------------------------------
 
-2018-02-13 by Martin Bless
-
-That is actually a good sign. Why? Read on!
-
-Shortly after an extension upload to the TER the documentation server will
-render the documentation that (hopefully!) comes with that version.
-BUT: At the moment this automatic rendering process still uses the old layout.
-Unfortunately the current server is very old and can't run the new toolchain.
-And we haven't managed to switch everything to a new server yet. That is why
-you initially may feel you've done something wrong because that outdated
-layout is used.
-At the moment I'm running the new toolchain manually "every now and then" from my
-local machine. In general that should happen at least once a day. The plan is,
-of course, to set up a fully automated process for that. But we can't foresee
-at the moment when exactly that will be.
-
-What does this mean? If you see your documentation in the old layout that
-actually is a good sign. It proofs that the documentation can be found and
-rendered. Just stay calm and patient until the new layout appears. That's the
-only thing you need to do.
-
-Easy - you can do it!
+Moved to :ref:`h2document:tip-extension-rendered-old-layout`
 
 
 .. _news-2018-02-02:


### PR DESCRIPTION
Move Tip to "Writing Documenation"

Related: https://github.com/TYPO3-Documentation/TYPO3CMS-Guide-HowToDocument/pull/63