### PR TITLE
Regroup lists of manuals on "Tutorials and Guides"

### DIFF
--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -31,7 +31,6 @@ use_opensearch       =
 
 [intersphinx_mapping]
 
-h2document    = https://docs.typo3.org/typo3cms/HowToDocument/
 t3api         = https://typo3.org/api/typo3cms/
 t3cgl         = https://docs.typo3.org/typo3cms/CodingGuidelinesReference/
 t3contribute  = https://docs.typo3.org/typo3cms/ContributionWorkflowGuide/
@@ -56,8 +55,9 @@ t3tsref       = https://docs.typo3.org/typo3cms/TyposcriptReference/
 t3tssyntax    = https://docs.typo3.org/typo3cms/TyposcriptSyntaxReference/
 t3viewhelper  = https://docs.typo3.org/typo3cms/ViewHelperReference/
 
-rendert3docs  = https://docs.typo3.org/typo3cms/RenderTYPO3DocumentationGuide/
 h2document    = https://docs.typo3.org/typo3cms/HowToDocument/
+rendert3docs  = https://docs.typo3.org/typo3cms/RenderTYPO3DocumentationGuide/
+
 
 
 [notify]

--- a/Documentation/typo3cms/GuidesAndTutorials/Index.rst
+++ b/Documentation/typo3cms/GuidesAndTutorials/Index.rst
@@ -12,25 +12,30 @@ Tutorials and Guides
 .. toctree::
    :hidden:
 
-   Contribution Workflow ➜                 <https://docs.typo3.org/typo3cms/ContributionWorkflowGuide/>
-   Documentation Rendering With Docker ➜   <https://github.com/t3docs/docker-render-documentation/blob/master/README.rst>
-   Extbase & Fluid ➜                       <https://docs.typo3.org/typo3cms/ExtbaseGuide/>
+   Getting Started Tutorial ➜              <https://docs.typo3.org/typo3cms/GettingStartedTutorial/>
+   Installation & Upgrade Guide ➜        <https://docs.typo3.org/typo3cms/InstallationGuide/>
    Frontend Localization ➜                 <https://docs.typo3.org/typo3cms/FrontendLocalizationGuide/>
-   Getting Started ➜                       <https://docs.typo3.org/typo3cms/GettingStartedTutorial/>
-   Installation and Upgrade ➜              <https://docs.typo3.org/typo3cms/InstallationGuide/>
-   Sitepackage Tutorial ➜                  <https://docs.typo3.org/typo3cms/SitePackageTutorial/>
-   Templating Tutorial➜                    <https://docs.typo3.org/typo3cms/TemplatingTutorial/>
    Tutorial for Editors ➜                  <https://docs.typo3.org/typo3cms/EditorsTutorial/>
    TypoScript in 45 Minutes ➜              <https://docs.typo3.org/typo3cms/TyposcriptIn45MinutesTutorial/>
+   Sitepackage Tutorial ➜                  <https://docs.typo3.org/typo3cms/SitePackageTutorial/>
+   Templating Tutorial ➜                    <https://docs.typo3.org/typo3cms/TemplatingTutorial/>
+   Developing TYPO3 Extensions with Extbase and Fluid (book)  ➜ <https://docs.typo3.org/typo3cms/ExtbaseFluidBook/Index.html>
+   Extbase & Fluid Guide ➜                       <https://docs.typo3.org/typo3cms/ExtbaseGuide/>
+   Core Contribution Guide ➜               <https://docs.typo3.org/typo3cms/ContributionWorkflowGuide/>
    Writing Documentation ➜                 <https://docs.typo3.org/typo3cms/HowToDocument/>
+   Documentation Rendering With Docker ➜   <https://github.com/t3docs/docker-render-documentation/blob/master/README.rst>
 
-Tutorials
-=========
+.. _getting-started:
 
-The official *tutorials* provide step-by-step introductions into the
-TYPO3 CMS world. If you are new to TYPO3 CMS, please go through the
-tutorials below in the order in which they are listed, which
-represents a logical progression in the knowledge of the product.
+Getting Started
+===============
+
+It is recommended to begin with the :ref:`t3start:start` and then continue
+with the documentation that is best suited for your background and the
+task at hand. So, if you are a developer, look in the :ref:`tutguides-developers`
+section on this page. There are also sections for :ref:`tutguides-editors`,
+:ref:`tutguides-integrators`, :ref:`tutguides-devops`, :ref:`tutguides-sysad`
+and :ref:`tutguides-docs`.
 
 
 .. t3-field-list-table::
@@ -45,11 +50,65 @@ represents a logical progression in the knowledge of the product.
    :Description:  The official tutorial to discover the main features and concepts of TYPO3 CMS.
                   It is based on the Introduction Package.
 
+ - :Title:        :ref:`t3install:start`
+   :Category:     Installation & Upgrade
+   :Description:  How to **install** TYPO3 (with or without composer) and
+                  how to **upgrade** an existing installation.
+
+ - :Title:        :ref:`t3l10n:start`
+   :Category:     Translation
+   :Description:  Everything you need to know about **multiple languages**
+                  and **translation** in TYPO3.
+
+.. tip::
+
+   Did you know, you can click on "Related links" at the bottom of a page in most
+   manuals to select a different version? The versions of the manual correspond to the TYPO3
+   version. :ref:`Read more ... <usage-version-selector>`
+
+.. _tutguides-editors:
+
+Editors
+=======
+
+For a detailed list of resources see :ref:`t3start:next-steps-editors`
+in the "Getting Started Tutorial".
+
+
+.. t3-field-list-table::
+ :header-rows: 1
+
+ - :Title:        Title
+   :Category:     Category
+   :Description:  Description
+
+ - :Title:        `Tutorial for Editors <https://docs.typo3.org/typo3cms/EditorsTutorial/>`__
+   :Category:     Editing
+   :Description:  How to create pages and content elements, access control
+                  and working with multiple languages.
+
+.. _tutguides-integrators:
+
+Integrators
+===========
+
+For a detailed list of resources see :ref:`t3start:next-steps-developers`
+in the "Getting Started Tutorial". Integrators should also look in the
+:ref:`references` section.
+
+.. t3-field-list-table::
+ :header-rows: 1
+
+ - :Title:        Title
+   :Category:     Category
+   :Description:  Description
+
+
  - :Title:        :ref:`TypoScript in 45 Minutes <t3ts45:start>`
    :Category:     Development / Integration
    :Description:  TypoScript is a configuration language that is specific to TYPO3.
                   This guide will walk you through the basics. For more information
-                  see :ref:`t3tsref:start`.
+                  see :ref:`t3tsref:start` and :ref:`t3coreapi:typoscript-syntax-start`.
 
  - :Title:        `Sitepackage Tutorial <https://docs.typo3.org/typo3cms/SitePackageTutorial/>`__
    :Category:     Development / Integration
@@ -68,16 +127,14 @@ represents a logical progression in the knowledge of the product.
                   <https://docs.typo3.org/typo3cms/SitePackageTutorial/>`__
                   covers FLUIDTEMPLATE as well.
 
- - :Title:        `Tutorial for Editors <https://docs.typo3.org/typo3cms/EditorsTutorial/>`__
-   :Category:     Editing
-   :Description:  How to create pages and content elements, access control
-                  and working with multiple languages.
+.. _tutguides-developers:
 
-Guides and Books
-================
+Developers
+==========
 
-*Guides* provide an in-depth exploration of a particular topic, like installation of TYPO3 or templating.
-
+For a detailed list of resources see :ref:`t3start:next-steps-developers`
+in the "Getting Started Tutorial". Developers should also look in the
+:ref:`references` section.
 
 .. t3-field-list-table::
  :header-rows: 1
@@ -86,22 +143,7 @@ Guides and Books
    :Category:     Category
    :Description:  Description
 
- - :Title:        :ref:`t3install:start`
-   :Category:     Installation & Upgrade
-   :Description:  How to **install** TYPO3 (with or without composer) and
-                  how to **upgrade** an existing installation.
-
- - :Title:        :ref:`t3l10n:start`
-   :Category:     Translation
-   :Description:  Everything you need to know about **multiple languages**
-                  and **translation** in TYPO3.
-
- - :Title:        :ref:`t3contribute:start`
-   :Category:     Development
-   :Description:  How to contribute to the **TYPO3 codebase** and how to
-                  **submit issues** (e.g. Bug reports).
-
- - :Title:        :ref:`t3extbasebook:start`
+ - :Title:        :ref:`Developing TYPO3 Extensions with Extbase and Fluid (book) <t3extbasebook:start>`
    :Category:     Development
    :Description:  An extensive walkthrough on extension development for
                   TYPO3 using the **Extbase** framework and **Fluid**
@@ -113,6 +155,63 @@ Guides and Books
                   for extension development but is
                   not a comprehensive Guide or Tutorial at this point.
                   Also available a complete :ref:`ViewHelper reference <t3viewhelper:start>`.
+
+ - :Title:        :ref:`t3contribute:start`
+   :Category:     Development
+   :Description:  How to contribute to the **TYPO3 codebase** and how to
+                  **submit issues** (e.g. Bug reports).
+
+
+
+.. _tutguides-devops:
+
+DevOps
+======
+
+.. t3-field-list-table::
+ :header-rows: 1
+
+ - :Title:        Title
+   :Category:     Category
+   :Description:  Description
+
+ - :Title:        `TYPO3 Surf <https://docs.typo3.org/surf/>`__
+   :Category:     Deployment
+   :Description:  Surf package is a complete automated deployment tool.
+
+
+
+
+.. _tutguides-sysad:
+
+System Administrators
+=====================
+
+The following guides or sections should be relevant for you:
+
+* :ref:`t3install:start`
+* :ref:`Security Guidelines for System Administrators <t3coreapi:security-administrators>`
+
+
+
+
+.. _tutguides-docs:
+
+Documentation Writers
+=====================
+
+The following  is about contributing to the documentation on docs.typo3.org,
+to the Changelog in the TYPO3 core and for adding documentation to an
+extension.
+
+A good start page is :ref:`h2document:getting-started` in "Writing Documentation".
+
+.. t3-field-list-table::
+ :header-rows: 1
+
+ - :Title:        Title
+   :Category:     Category
+   :Description:  Description
 
  - :Title:        :ref:`h2document:start`
    :Category:     Documentation
@@ -134,8 +233,9 @@ Guides and Books
                   `Render TYPO3 Documentation With Docker <https://github.com/t3docs/docker-render-documentation/blob/master/README.rst>`__
                   for information about local rendering with Docker.
 
-Example Manual
-==============
+
+Example Manuals
+---------------
 
 *Example manuals* for both extensions and official manuals,
 which also serve as guidelines to the usage of reStructuredText.
@@ -149,3 +249,5 @@ which also serve as guidelines to the usage of reStructuredText.
 
  - :Title:        `Extension Manual <https://docs.typo3.org/typo3cms/ExtensionManualExample>`__
    :Description:
+
+


### PR DESCRIPTION
- The previous recommendation to read in the order listed might have been
  good advice in the past but is no longer applicable
- Developers, editors, etc. have different requirements. Some of the guides
  and tutorials are not useful at all to some groups.
- The differentiation between tutorials and guides is of little value here.
  Some of the guides are actually targeted for beginners.

For this reason, this change groups the manuals by target audience.
Additionally, we refer to (already existing) pages "Next steps"
in "Getting Started Tutorial".