### PR TITLE
Rename news to "changelog"

### DIFF
--- a/Documentation/Home/About/News/2019/Index.rst
+++ b/Documentation/Home/About/News/2019/Index.rst
@@ -12,6 +12,11 @@
 2019
 ====
 
+.. note::
+
+   Only major changes will be documented here. For all
+   changes, see commit messages in respective GitHub
+   repositories.
 
 
 .. _news-2019-06-26:
@@ -52,6 +57,20 @@ You can find links to all available ViewHelper references on the
 #. phase 1: deprecation notice on every page
 #. phase 2: remove and redirect (except ViewHelper reference for 6.2. and 8.7)
 #. phase 3: removal all (ViewHelper refs will be redirected to automatically generated)
+
+
+.. _news-2019-06-29:
+.. rst-class:: panel panel-default
+
+Migration of Extension Documentation
+====================================
+
+The documentation server docs.typo3.org moved to a new
+infrastructure. `Read more ... <https://typo3.org/article/docstypo3org-gets-new-infrastructure/>`__.
+
+Extension authors must migrate their documentation:
+
+* :ref:`h2document:migrate`
 
 
 .. _news-2019-05-09:

--- a/Documentation/Home/About/News/Index.rst
+++ b/Documentation/Home/About/News/Index.rst
@@ -1,11 +1,15 @@
 
 .. _news:
 
-==================
-Documentation News
-==================
+=======================
+Documentation Changelog
+=======================
 
-**List of news:**
+.. note::
+
+   Only major changes will be documented here. For all
+   changes, see commit messages in respective GitHub
+   repositories.
 
 .. toctree::
 

--- a/Documentation/HowToUse/Index.rst
+++ b/Documentation/HowToUse/Index.rst
@@ -1,0 +1,8 @@
+
+.. include:: ../Includes.txt
+
+.. _how-to-use-docs:
+
+==============================
+How to use TYPO3 documentation
+==============================

--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -67,8 +67,8 @@ Did You Know?
 .. | :ref:`More tips on writing documentation <h2document:Tip-of-the-day>`
 
 
-Latest Documentation News
--------------------------
+Documentation Changelog
+-----------------------
 
 
 .. sidebar:: Quickstart extension documentation
@@ -79,25 +79,17 @@ Latest Documentation News
 .. end of sidebar
 
 -  2019-06-26 :ref:`news-2019-06-26`
--  2019-05-29 `docs.typo3.org Gets New Infrastructure <https://typo3.org/article/docstypo3org-gets-new-infrastructure/>`__ (typo3.org)
+-  2019-05-29 :ref:`news-2019-06-29`
 -  2019-05-20 `Recap: Docs Team Joins typo3.org Sprint Wiesbaden <https://typo3.org/article/recap-docs-team-joins-typo3org-sprint-wiesbaden/>`__ (typo3.org)
 -  2019-05-09 :ref:`news-2019-05-09`
 -  2019-05-09 :ref:`news-2019-05-09-2`
 
-:ref:`All News on docs.typo3.org <news>`
+:ref:`All Documentation Changelogs <news>` |
+`News on typo3.org <https://typo3.org/community/teams/documentation/#c9876>`__
 
 .. rst-class:: clear-both
 
 
-
-.. the menu (now) has the following order:
-   1. Official Documentation
-   2. Community Documentation
-   3. About documentation: "About"
-   4. Additional information, like Teams: typo3cms/Teams
-
-.. todo: Define what is "official" documentation, what is "community"
-   documentation, e.g. surf, snippets, cheat sheets etc.
 
 .. toctree::
    :hidden:


### PR DESCRIPTION
- currently we have news on docs.typo3.org and typo3.org
- documenting changes is important, but not every change warrants
  a news on typo3.org
- this way, we use similar terminology to core