### PR TITLE
[TASK] Remove outdated link to Extbase/Fluid cheat sheets

### DIFF
--- a/Documentation/Home/CheatSheets.rst
+++ b/Documentation/Home/CheatSheets.rst
@@ -77,21 +77,6 @@ An illustration of the different includes, which are supported by the Page rende
 * `Edit <https://github.com/TYPO3-Documentation/DocsTypo3Org-Homepage/tree/master/Resources/Public/CheatSheets/T3_pageinclude_sheet%20v1.odp>`__
 
 
-Extbase / Fluid
-===============
-
-2 Extbase Cheat Sheets and 2 Fluid Cheat Sheets
------------------------------------------------
-
-*by Patrick Lobacher*
-
-Everything around Extbase and Fluid: Extension directory structure, TypoScript settings, API for ActionController,
-View and Request. And for Fluid: Fluidtemplate and usage of ViewHelpers.
-
-* `Download <http://www.lobacher.de/files/cs/ExtbaseFluidCheatSheet_3.02_pluswerk.pdf>`__
-
-
-
 TCA
 ===
 


### PR DESCRIPTION
I have been informed that people still download and use Patrick's Extbase/Fluid cheat sheets which is outdated (TYPO3 v7) and causes confusion. A number of questions on Stackoverflow and on Slack apparently popped up recently referring to this document. Please remove the reference from the docs.typo3.org "CheatSheets" page.