### PR TITLE
Remove "Teams" item from menu

### DIFF
--- a/Documentation/Home/Contribute.rst
+++ b/Documentation/Home/Contribute.rst
@@ -1,0 +1,15 @@
+.. include:: ../Includes.txt
+
+.. _contribute:
+
+
+==========
+Contribute
+==========
+
+.. toctree::
+
+   Contribute to Core  ➜  <https://docs.typo3.org/m/typo3/guide-contributionworkflow/master/en-us/>
+   Contribute to Documentation  ➜  <https://docs.typo3.org/typo3cms/HowToDocument/WritingDocsOfficial/Index.html>
+   Contribute to typo3.org website ➜  <https://docs.typo3.org/m/typo3/team-t3oteam/master/en-us/>
+

--- a/Documentation/Home/Teams.rst
+++ b/Documentation/Home/Teams.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 .. include:: ../Includes.txt
 
 .. _teams:
@@ -8,32 +10,8 @@
 TYPO3 Teams
 ===========
 
-`Official Team Page ➜ <https://typo3.org/community/teams/academic-committee/>`__ (typo3.org)
-==========================================================================================
+Please see the
 
+.. rst-class:: horizbuttons-tip-xxl
 
-About the Teams @ Work Projects
-===============================
-
-The "Teams @ Work" projects for the `T3O Team <https://docs.typo3.org/typo3cms/Teams/T3oTeam/>`__
-(typo3.org website) and the `T3DocTeam <https://docs.typo3.org/typo3cms/Teams/T3DocTeam/>`__ are documentation
-projects based on the same technology as any documentation manual.
-They can be used as information for the team members (and interested contributors).
-They are (usually) hosted on GitHub in the
-`TYPO3-Teams-Documentation <https://github.com/TYPO3-Teams-Documentation/>`__
-organization (except for the doc manual, it is hosted on GitHub in the
-`TYPO3-Documentation <https://github.com/TYPO3-Documentation>`__ organization,
-like the other manuals).
-
-If you are in one of the official TYPO3 teams and wish to start a
-"Teams @ Work" project for your team, contact the Documentation Team in
-the `#typo3-documentation <https://typo3.slack.com/messages/C028JEPJL>`__
-Slack channel. We are happy to help with documentation in any way, if we can.
-
--- Documentation Team
-
-
-.. toctree::
-
-   T3DocTeam @ Work ➜  <https://docs.typo3.org/typo3cms/Teams/T3DocTeam/>
-   T3O Team @ Work  ➜  <https://docs.typo3.org/typo3cms/Teams/T3oTeam/>
+- `team pages on typo3.org <https://typo3.org/community/teams/>`__

--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -114,5 +114,5 @@ Documentation Changelog
    Tell Me Something About Topic X  ➜  <https://docs.typo3.org/typo3cms/TellMeSomethingAbout/>
    Snippets  ➜  <https://docs.typo3.org/typo3cms/Snippets/>
    Home/About/Index
-   Contribute  ➜  <https://docs.typo3.org/typo3cms/HowToDocument/WritingDocsOfficial/Index.html>
+   Home/Contribute
 

--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -115,4 +115,4 @@ Documentation Changelog
    Snippets  ➜  <https://docs.typo3.org/typo3cms/Snippets/>
    Home/About/Index
    Contribute  ➜  <https://docs.typo3.org/typo3cms/HowToDocument/WritingDocsOfficial/Index.html>
-   Home/Teams
+


### PR DESCRIPTION
- to make docs.typo3.org more user friendly, remove rarely used
  menu items
- the "Contribute" menu item is changed to include a link to contribution for core and t3o

