### PR TITLE
Change links to tsref to anchor text "TypoScript Template Reference"

### DIFF
--- a/Documentation/Home/About/News/2018/Index.rst
+++ b/Documentation/Home/About/News/2018/Index.rst
@@ -256,9 +256,9 @@ single commits the last days:
   information should be looked up in. The term "Core API" will probably change at
   some point to reflect this, too.
 
-* The :ref:`TSconfig Reference <t3tsconfig:start>` received a major overhaul. This document
+* The :ref:`t3tsconfig:start` received a major overhaul. This document
   is one of the most important documents next to the other two references, namely the
-  :ref:`TypoScript Reference <t3tsref:start>` and the :ref:`TCA Reference <t3tca:start>`.
+  :ref:`t3tsref:start` and the :ref:`TCA Reference <t3tca:start>`.
   The TSconfig Reference didn't receive too much love within the last years, but now it comes with
   a reworked menu structure, a lot of streamlined information and a simplified property listing
   with more examples. Various chapters have been moved around between the main core documents

--- a/Documentation/Home/References.rst
+++ b/Documentation/Home/References.rst
@@ -123,5 +123,5 @@ for, these obsoleted documents are listed here:
    Core Changelog    ➜ <https://docs.typo3.org/c/typo3/cms-core/master/en-us/>
    TCA ➜               <https://docs.typo3.org/m/typo3/reference-tca/master/en-us/>
    TSconfig ➜          <https://docs.typo3.org/m/typo3/reference-tsconfig/master/en-us/>
-   TypoScript Reference ➜ <https://docs.typo3.org/m/typo3/reference-typoscript/master/en-us/>
+   TypoScript Template Reference ➜ <https://docs.typo3.org/m/typo3/reference-typoscript/master/en-us/>
    ViewHelper Reference ➜ <https://docs.typo3.org/other/typo3/view-helper-reference/9.5/en-us/>

--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -21,7 +21,7 @@ Quick links
 - `Core ChangeLog <https://docs.typo3.org/typo3cms/extensions/core/latest/>`__
 - :ref:`TCA Reference <t3tca:Start>`
 - :ref:`TSconfig Reference <t3tsconfig:Start>`
-- :ref:`TypoScript Reference <t3tsref:Start>`
+- :ref:`t3tsref:Start`
 - :ref:`ViewHelper Reference <t3viewhelper:Start>`
 - :ref:`Contribute to Documentation <h2document:contribute>`
 - :ref:`How you can Help <h2document:docs-official-how-you-can-help>`


### PR DESCRIPTION
* "TypoScript Reference" was renamed to "TypoScript Template Reference", see
  https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-Typoscript/pull/264
* We change anchor texts here to use new title
* Wherever possible we omit anchor texts, so title will always be updated
  automatically in the future

Related: TYPO3-Documentation/T3DocTeam#77
Related: TYPO3-Documentation/T3DocTeam#120
Related: https://decisions.typo3.org/t/clarification-of-term-typoscript/560