### PR TITLE
Remove surf from main menu

### DIFF
--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -109,7 +109,6 @@ Documentation Changelog
    Home/References
    Home/SystemExtensions
    Home/Extensions
-   Surf for Deployment  ➜  <https://docs.typo3.org/surf/>
    Cheat Sheets ➜ <https://docs.typo3.org/m/typo3/docs-cheatsheets/master/en-us/>
    Tell Me Something About Topic X  ➜  <https://docs.typo3.org/typo3cms/TellMeSomethingAbout/>
    Snippets  ➜  <https://docs.typo3.org/typo3cms/Snippets/>


### PR DESCRIPTION
As surf is not listed on the "Tutorials and Guides" page,
it can be removed from the main menu.