### PR TITLE
[FEATURE] Improve start page

### DIFF
--- a/Documentation/Home/GettingStarted.rst
+++ b/Documentation/Home/GettingStarted.rst
@@ -1,0 +1,26 @@
+.. include:: ../Includes.txt
+
+.. _start-getting-stared:
+
+===============
+Getting Started
+===============
+
+If you are new to TYPO3, it is recommended that you start with these resources.
+
+Installation and basic setup:
+    * Setup up your system according to the :ref:`System requirements <t3install:system-requirements>`
+      for installing TYPO3
+    * Follow :ref:`Quick installation with Composer <t3install:install-via-composer>`
+      to install TYPO3
+    * Set up the :ref:`site configuration <sitehandling-basics>` in the backend to configure
+      the domain, languages, URLs and error pages.
+
+Tutorials:
+    * The :ref:`t3start:start` walks
+      you through the interface for editing content and configuring the TYPO3
+      installation. You need a browser and a working TYPO3 installation.
+
+Get Help:
+    * You can ask for support via StackOverflow or Slack (https://typo3.slack.com)
+    * Find out more on the `help page <https://typo3.org/help>`__

--- a/Documentation/Home/WhatsNew.rst
+++ b/Documentation/Home/WhatsNew.rst
@@ -112,7 +112,7 @@ Changes in TYPO3 documentation are announced via the following channels:
 
 * `News on typo3.org <https://typo3.org/community/teams/documentation#c9876>`__:
   Used to report about events, used for announcement of major changes
-* `Twitter T3DocTeam <https://twitter.com/T3docTeam>`__: Major and minor changes,
+* `Twitter T3DocTeam <https://twitter.com/T3docTeam>`__C: Major and minor changes,
   give contribution tips
 *  :ref:`news`: Describes changes that are announced on Twitter
 * #typo3-documentation channel on Slack

--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -1,99 +1,160 @@
-
 .. include:: Includes.txt
 
+.. _start:
 
 ===========================================
 Welcome to the official TYPO3 Documentation
 ===========================================
 
-.. .. rst-class:: horizbuttons-tip-xxl
-..
-.. - How to find my answer here
+TYPO3 CMS is an Open Source Enterprise Content Element System based on PHP.
+
+__________________________________________________
+
+Quick links:
+    :ref:`t3install:start` |
+    :ref:`TYPO3 Explained <t3coreapi:Start>` |
+    `Core ChangeLog <https://docs.typo3.org/typo3cms/extensions/core/latest/>`__ |
+    :ref:`TCA Reference <t3tca:Start>` |
+    :ref:`TSconfig Reference <t3tsconfig:Start>` |
+    :ref:`TypoScript Reference <t3tsref:Start>` |
+    :ref:`ViewHelper Reference <t3viewhelper:Start>` |
+    :ref:`Core Contribution Guide <t3contribute:start>`
+
+__________________________________________________
+
+How the documentation is organized
+==================================
+
+* :ref:`Tutorials and Guides <tutorials>` is a comprehensive list of
+  further guides and tutorials for each area of the CMS.
+* The :ref:`references` section provides information about the TYPO3 core
+  for a technical audience (developers, integrators). The main reference
+  manual is :ref:`t3coreapi:start`.
+* :ref:`System-Extensions` contains documentation for system
+  extensions. These are extensions that are included in the
+  TYPO3 core.
 
 
-Quick links
------------
+__________________________________________________
 
-.. rst-class:: horizbuttons-primary-m
+.. _start-theme:
 
-- :ref:`t3start:start`
-- :ref:`TYPO3 Explained <t3coreapi:Start>`
-- `Core ChangeLog <https://docs.typo3.org/typo3cms/extensions/core/latest/>`__
-- :ref:`TCA Reference <t3tca:Start>`
-- :ref:`TSconfig Reference <t3tsconfig:Start>`
-- :ref:`t3tsref:Start`
-- :ref:`ViewHelper Reference <t3viewhelper:Start>`
-- :ref:`Contribute to Documentation <h2document:contribute>`
-- :ref:`How you can Help <h2document:docs-official-how-you-can-help>`
-- :ref:`Writing reST <h2document:Formatting-with-reST>`
+Theme
+=====
 
+*Theme* | *Templating* | *Sitepackage*
 
+It is good practice to create a **sitepackage**. This is an extension which
+contains the resources required for a theme.
 
-Did You Know?
-------------------------------
+Sitepackage
+    * `Concept of Sitepackages <https://www.slideshare.net/benjaminkott/typo3-the-anatomy-of-sitepackages>`__
+    * :ref:`t3sitepackage:start`
 
-.. important:: Migrate Extension Documentation
+More introductions
+    * The `Fluid documentation <https://github.com/TYPO3/Fluid>`__
+      contains information about fluid. As it is an independant project, the documentation is not
+      maintained on docs.typo3.org.
+    * The system extension :ref:`fluid_styled_content <fsc:start>` handles the rendering of the default
+      set of content elements shipped with the core by using the template engine
+      `fluid <https://typo3.org/fluid>`__
+    * :ref:`Backend layouts <t3coreapi:be-layout>`
+    * :ref:`Create custom content elements <t3coreapi:adding-your-own-content-elements>`
 
-   As of May 29th 2019, new infrastructure now powers docs.typo3.org.
-   For extensions developers, some :ref:`migration tasks <h2document:migrate>`
-   are required to ensure that your extensions documentation is rendered automatically
-   on the new infrastructure.
+References
+    * :ref:`t3tsref:start`
+    * :ref:`t3viewhelper:start`
 
-.. sidebar:: New to TYPO3?
+__________________________________________________
 
-   If you are new to TYPO3, it is recommended that you visit the
-   :ref:`t3start:start` guide. This is a great resource for new
-   users who want to begin using TYPO3.
+.. _start-extdev:
 
-   The :ref:`Tutorials and Guides <tutorials>` is a comprehensive list
-   of guides and tutorials for each area of the CMS.
+Extension development
+=====================
 
-   For developers, the :ref:`t3coreapi:start` guide covers
-   TYPO3's core in detail.
+* :ref:`QueryBuilder <t3coreapi:database-query-builder>` based on
+  Doctrine
+* :ref:`t3coreapi:DependencyInjection`
+* :ref:`t3coreapi:request-handling`
+* :ref:`t3coreapi:mail`
 
-   The :ref:`References <references>` section is a useful guide that
-   lists each area of TYPO3's core for further reading.
+More topics can be found in the :ref:`API Overview <t3coreapi:api-overview>`
+in "TYPO3 Explained".
 
-.. End of sidebar
+Are you are an extension author and want to add documentation?
+Please read :ref:`h2document:how-to-start-documentation-for-ext`.
 
+__________________________________________________
 
--  Documentation is available for several versions of TYPO3. If you are using an older
-   version of TYPO3 (before TYPO3 9.5), make sure that the version of the CMS you are using
-   matches the documentation you are viewing. :ref:`Read more ... <usage-version-selector>`
--  You can ask for support via StackOverflow or Slack. Find out more at https://typo3.org/help
--  You can find out more about the TYPO3 CMS on https://typo3.org/cms/
--  You can click on the "Edit me on GitHub" button to edit any page and contribute directly to TYPO3
-   documentation! :ref:`Read more ... <h2document:docs-contribute>`
+.. _start-configuration:
 
-:ref:`More usage tips <usage-tips>` | :ref:`FAQ for extension authors <h2document:tips-extension-authors>`
+Configuration
+=============
 
+A major feature for TYPO3 is its configurability. The :ref:`t3coreapi:config-overview`
+in "TYPO3 Explained" gives you an overview of various configuration languages.
 
+Specifically, you might want to
 
+* Set up the :ref:`site configuration <sitehandling-basics>` in the backend to configure
+  the domain, languages, URLs and error pages.
+* Configure :ref:`rte_ckeditor <ckeditor:configuration>`
+  to enhance the editing experience when handling rich text editing.
+* :ref:`Configure the form system extension <form:quickstartIntegrators>` to create
+  custom forms for the frontend.
+* :ref:`Configure backend users <t3start:user-management>`
 
-Changes in Documentation
-------------------------
+For further information, look in the references:
 
-.. --------------------------
-.. sidebar:: Quickstart extension documentation
+* :ref:`t3tsref:start`: TypoScript is used for configuration *and* templating.
+* :ref:`t3tca:start`: TCA is specific to database fields and how they behave and
+  can be edited in the backend.
+* :ref:`t3tsconfig:start`: s used to configure and customize the backend on a page
+  (page TSconfig) and a user or group basis (user TSconfig).
 
-   You are an extension author and want to add documentation?
-   Please read :ref:`h2document:how-to-start-documentation-for-ext`
+__________________________________________________
 
-.. end of sidebar
-.. --------------------------
+.. _start-localization:
 
+Multiple languages
+==================
 
-* 2020-01-02: :ref:`new_documentation`
-* 2020-01-03: :ref:`news-2020-link-to-versions`
+*Internationalization* | *Translation* | *Multiple Languages*
 
-:ref:`All Documentation Changelogs <news>` |
-`News on typo3.org <https://typo3.org/community/teams/documentation/#c9876>`__
+* :ref:`Supported languages <t3coreapi:i18n_languages>`
+* :ref:`Manage backend languages <t3start:changing-backend-language>`
+* :ref:`Working with languages as an editor <t3editors:languages>`
 
-.. rst-class:: clear-both
+__________________________________________________
+
+.. _start-coredev:
+
+Core development contribution
+=============================
+
+    * :ref:`Create a patch <t3contribute:quickstart-create-a-patch>`
+    * :ref:`Commit message rules <t3contribute:commitmessage>`
+    * :ref:`Setup an installation with DDEV <t3contribute:ddev>`
+
+__________________________________________________
+
+.. _start-contribute-docs:
+
+Contribute to official documentation
+====================================
+
+You are welcome to click on the "Edit me on GitHub" button on any page
+to propose a change in the official documentation if you see something that
+can be improved.
+
+* :ref:`h2document:docs-contribute` gives a good introduction to the workflow
+* The documentation is editied in text files using reStructuredText syntax.
+  Use the :ref:`rest-cheat-sheet` to lookup most commonly used directives.
 
 .. toctree::
    :hidden:
 
+   Home/GettingStarted
    Home/GuidesAndTutorials
    Home/References
    Home/SystemExtensions

--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -44,7 +44,7 @@ Theme
 
 *Theme* | *Templating* | *Sitepackage*
 
-It is good practice to create a **sitepackage**. This is an extension which
+It is good practice to create a **Sitepackage**. This is an extension which
 contains the resources required for a theme.
 
 Sitepackage
@@ -53,11 +53,11 @@ Sitepackage
 
 More introductions
     * The `Fluid documentation <https://github.com/TYPO3/Fluid>`__
-      contains information about fluid. As it is an independant project, the documentation is not
+      contains information about Fluid. As it is an independent project, the documentation is not
       maintained on docs.typo3.org.
     * The system extension :ref:`fluid_styled_content <fsc:start>` handles the rendering of the default
       set of content elements shipped with the core by using the template engine
-      `fluid <https://typo3.org/fluid>`__
+      `Fluid <https://typo3.org/fluid>`__
     * :ref:`Backend layouts <t3coreapi:be-layout>`
     * :ref:`Create custom content elements <t3coreapi:adding-your-own-content-elements>`
 
@@ -109,7 +109,7 @@ For further information, look in the references:
 * :ref:`t3tsref:start`: TypoScript is used for configuration *and* templating.
 * :ref:`t3tca:start`: TCA is specific to database fields and how they behave and
   can be edited in the backend.
-* :ref:`t3tsconfig:start`: s used to configure and customize the backend on a page
+* :ref:`t3tsconfig:start`: is used to configure and customize the backend on a page
   (page TSconfig) and a user or group basis (user TSconfig).
 
 __________________________________________________
@@ -148,7 +148,7 @@ to propose a change in the official documentation if you see something that
 can be improved.
 
 * :ref:`h2document:docs-contribute` gives a good introduction to the workflow
-* The documentation is editied in text files using reStructuredText syntax.
+* The documentation is edited in text files using reStructuredText syntax.
   Use the :ref:`rest-cheat-sheet` to lookup most commonly used directives.
 
 .. toctree::

--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -58,6 +58,11 @@ t3tsconfig    = https://docs.typo3.org/m/typo3/reference-tsconfig/master/en-us/
 t3tsref       = https://docs.typo3.org/m/typo3/reference-typoscript/master/en-us/
 t3viewhelper  = https://docs.typo3.org/other/typo3/view-helper-reference/master/en-us/
 
+# sysext
+ckeditor      = https://docs.typo3.org/c/typo3/cms-rte-ckeditor/master/en-us/
+fsc           = https://docs.typo3.org/c/typo3/cms-fluid-styled-content/master/en-us/
+form          = https://docs.typo3.org/c/typo3/cms-form/master/en-us/
+
 
 # outdated: should no longer be used as reference
 t3cgl         = https://docs.typo3.org/m/typo3/reference-coding-guidelines/master/en-us/

--- a/Documentation/_not_used/Startpage.rst
+++ b/Documentation/_not_used/Startpage.rst
@@ -1,0 +1,54 @@
+:orphan:
+
+.. include:: ../Includes.txt
+
+============================
+Misc. (to be structured ...)
+============================
+
+Did You Know?
+=============
+
+-  Documentation is available for several versions of TYPO3. If you are using an older
+   version of TYPO3 (before TYPO3 9.5), make sure that the version of the CMS you are using
+   matches the documentation you are viewing. :ref:`Read more ... <usage-version-selector>`
+-  You can ask for support via StackOverflow or Slack. Find out more at https://typo3.org/help
+-  You can find out more about the TYPO3 CMS on https://typo3.org/cms/
+-  You can click on the "Edit me on GitHub" button to edit any page and contribute directly to TYPO3
+   documentation! :ref:`Read more ... <h2document:docs-contribute>`
+
+:ref:`More usage tips <usage-tips>` | :ref:`FAQ for extension authors <h2document:tips-extension-authors>`
+
+Extension Documentation
+=======================
+
+.. important:: Migrate Extension Documentation
+
+   As of May 29th 2019, new infrastructure now powers docs.typo3.org.
+   For extensions developers, some :ref:`migration tasks <h2document:migrate>`
+   are required to ensure that your extensions documentation is rendered automatically
+   on the new infrastructure.
+
+
+
+
+.. --------------------------
+.. sidebar:: Quickstart extension documentation
+
+   You are an extension author and want to add documentation?
+   Please read :ref:`h2document:how-to-start-documentation-for-ext`
+
+.. end of sidebar
+.. --------------------------
+
+Changes in Documentation
+========================
+
+
+* 2020-01-02: :ref:`new_documentation`
+* 2020-01-03: :ref:`news-2020-link-to-versions`
+
+:ref:`All Documentation Changelogs <news>` |
+`News on typo3.org <https://typo3.org/community/teams/documentation/#c9876>`__
+
+.. rst-class:: clear-both


### PR DESCRIPTION
- Add 1 sentence about what TYPO3 is
- Add subsections for major TYPO3 topics
- Add "Getting Started" section
- Ad "How the documentation is organized"
- Add links to documentation

Some parts that were kept:

- get help

Some parts were removed:

- Link to "Migrate extension documentation": This link is on every
  extension documentation page that was not rendered, was communicated
  via email, typo3.org and TYPO3 association newsletter
- Link to typo3.org features. Once the new theme is deployed, there
  will be a topbar with links to typo3.org
- Information about version selection. Once new theme is deployed,
  the version selector will be more visisble and screenshots need
  to be changed

Resolves: #121