### PR TITLE
Update links to 10.4 where possible

### DIFF
--- a/Documentation/Home/GuidesAndTutorials.rst
+++ b/Documentation/Home/GuidesAndTutorials.rst
@@ -13,15 +13,15 @@ Tutorials and Guides
    :hidden:
 
    Core Contribution Guide             <https://docs.typo3.org/m/typo3/guide-contributionworkflow/master/en-us/>
-   Extensions with Extbase and Fluid   <https://docs.typo3.org/m/typo3/book-extbasefluid/master/en-us/>
-   Editors Tutorial                    <https://docs.typo3.org/m/typo3/tutorial-editors/master/en-us/>
+   Extensions with Extbase and Fluid   <https://docs.typo3.org/m/typo3/book-extbasefluid/10.4/en-us/>
+   Editors Tutorial                    <https://docs.typo3.org/m/typo3/tutorial-editors/10.4/en-us/>
    Extbase Guide                       <https://docs.typo3.org/m/typo3/guide-extbasefluid/master/en-us/>
-   Frontend Localization Guide         <https://docs.typo3.org/m/typo3/guide-frontendlocalization/master/en-us/>
-   Getting Started Tutorial            <https://docs.typo3.org/m/typo3/tutorial-getting-started/master/en-us/>
-   Installation & Upgrade Guide        <https://docs.typo3.org/m/typo3/guide-installation/master/en-us/>
-   Sitepackage Tutorial                <https://docs.typo3.org/m/typo3/tutorial-sitepackage/master/en-us/>
-   Templating Tutorial                 <https://docs.typo3.org/m/typo3/tutorial-templating/master/en-us/>
-   TypoScript in 45 Minutes            <https://docs.typo3.org/m/typo3/tutorial-typoscript-in-45-minutes/master/en-us/>
+   Frontend Localization Guide         <https://docs.typo3.org/m/typo3/guide-frontendlocalization/10.4/en-us/>
+   Getting Started Tutorial            <https://docs.typo3.org/m/typo3/tutorial-getting-started/10.4/en-us/>
+   Installation & Upgrade Guide        <https://docs.typo3.org/m/typo3/guide-installation/10.4/en-us/>
+   Sitepackage Tutorial                <https://docs.typo3.org/m/typo3/tutorial-sitepackage/10.4/en-us/>
+   Templating Tutorial                 <https://docs.typo3.org/m/typo3/tutorial-templating/10.4/en-us/>
+   TypoScript in 45 Minutes            <https://docs.typo3.org/m/typo3/tutorial-typoscript-in-45-minutes/10.4/en-us/>
    Writing Documentation               <https://docs.typo3.org/m/typo3/docs-how-to-document/master/en-us/>
 
 It is recommended to begin with the :ref:`t3start:start` and then continue
@@ -45,7 +45,8 @@ task at hand:
    :Description:  Description
 
  - :Title:        :ref:`t3start:start`
-   :Versions:     :ref:`master (10-dev) <t3start:start>` |
+   :Versions:     `master (11-dev) <https://docs.typo3.org/m/typo3/tutorial-getting-started/master/en-us/>`__ |
+                  `10.4 <https://docs.typo3.org/m/typo3/tutorial-getting-started/10.4/en-us/>`__ |
                   `9.5 <https://docs.typo3.org/m/typo3/tutorial-getting-started/9.5/en-us/>`__ |
                   `8.7 <https://docs.typo3.org/m/typo3/tutorial-getting-started/8.7/en-us/>`__ |
                   `7.6 <https://docs.typo3.org/m/typo3/tutorial-getting-started/7.6/en-us/>`__
@@ -54,21 +55,14 @@ task at hand:
                   It is based on the Introduction Package.
 
  - :Title:        :ref:`t3install:start`
-   :Versions:     :ref:`master (10.dev) <t3install:start>` |
+   :Versions:     `master (11-dev) <https://docs.typo3.org/m/typo3/guide-installation/master/en-us/>`__ |
+                  `10.4 <https://docs.typo3.org/m/typo3/guide-installation/10.4/en-us/>`__ |
                   `9.5 <https://docs.typo3.org/m/typo3/guide-installation/9.5/en-us/>`__ |
                   `8.7 <https://docs.typo3.org/m/typo3/guide-installation/8.7/en-us/>`__ |
                   `7.6 <https://docs.typo3.org/m/typo3/guide-installation/7.6/en-us/>`__
    :Category:     Installation & Upgrade
    :Description:  How to **install** TYPO3 (with or without composer) and
                   how to **upgrade** an existing installation.
-
-
-.. tip::
-
-   Did you know, you can click on "Related links" at the bottom of the menu in most
-   manuals to select a different version? The versions of the manual correspond to the TYPO3
-   version. :ref:`Read more ... <usage-version-selector>`
-
 
 
 .. _tutguides-editors:
@@ -89,7 +83,8 @@ in the "Getting Started Tutorial".
    :Description:  Description
 
  - :Title:        :ref:`t3editors:start`
-   :Versions:     :ref:`master (10-dev) <t3editors:start>` |
+   :Versions:     `master (11-dev) <https://docs.typo3.org/m/typo3/tutorial-editors/master/en-us/>`__ |
+                  `10.4 <https://docs.typo3.org/m/typo3/tutorial-editors/10.4/en-us/>`__ |
                   `9.5 <https://docs.typo3.org/m/typo3/tutorial-editors/9.5/en-us/>`__ |
                   `8.7 <https://docs.typo3.org/m/typo3/tutorial-editors/8.7/en-us/>`__ |
                   `7.6 <https://docs.typo3.org/m/typo3/tutorial-editors/7.6/en-us/>`__
@@ -116,7 +111,8 @@ in the "Getting Started Tutorial". Integrators should also look in the
 
 
  - :Title:        :ref:`t3ts45:start`
-   :Versions:     :ref:`master (10-dev) <t3ts45:start>` |
+   :Versions:     `master (11-dev) <https://docs.typo3.org/m/typo3/tutorial-typoscript-in-45-minutes/master/en-us/>`__ |
+                  `10.4 <https://docs.typo3.org/m/typo3/tutorial-typoscript-in-45-minutes/10.4/en-us/>`__ |
                   `9.5 <https://docs.typo3.org/m/typo3/tutorial-typoscript-in-45-minutes/9.5/en-us/>`__ |
                   `8.7 <https://docs.typo3.org/m/typo3/tutorial-typoscript-in-45-minutes/8.7/en-us/>`__ |
                   `7.6 <https://docs.typo3.org/m/typo3/tutorial-typoscript-in-45-minutes/7.6/en-us/>`__
@@ -126,7 +122,8 @@ in the "Getting Started Tutorial". Integrators should also look in the
                   see :ref:`t3tsref:start` and :ref:`t3coreapi:typoscript-syntax-start`.
 
  - :Title:        :ref:`t3sitepackage:start`
-   :Versions:     :ref:`master (10-dev) <t3sitepackage:start>` |
+   :Versions:     `master (11-dev) <https://docs.typo3.org/m/typo3/tutorial-sitepackage/master/en-us/>`__ |
+                  `10.4 <https://docs.typo3.org/m/typo3/tutorial-sitepackage/10.4/en-us/>`__ |
                   `9.5 <https://docs.typo3.org/m/typo3/tutorial-sitepackage/9.5/en-us/>`__ |
                   `8.7 <https://docs.typo3.org/m/typo3/tutorial-sitepackage/8.7/en-us/>`__
    :Category:     Development / Integration
@@ -135,7 +132,8 @@ in the "Getting Started Tutorial". Integrators should also look in the
                   :ref:`[read more] <news-2018-06-13>`
 
  - :Title:        :ref:`t3templating:start`
-   :Versions:     :ref:`master (10-dev) <t3templating:start>` |
+   :Versions:     `master (11-dev) <https://docs.typo3.org/m/typo3/tutorial-templating/master/en-us/>`__ |
+                  `10.4 <https://docs.typo3.org/m/typo3/tutorial-templating/10.4/en-us/>`__ |
                   `9.5 <https://docs.typo3.org/m/typo3/tutorial-templating/9.5/en-us/>`__ |
                   `8.7 <https://docs.typo3.org/m/typo3/tutorial-templating/8.7/en-us/>`__
    :Category:     Development / Integration
@@ -167,7 +165,8 @@ in the "Getting Started Tutorial". Developers should also look in the
    :Description:  Description
 
  - :Title:        :ref:`t3extbasebook:start`
-   :Versions:     :ref:`master (10-dev) <t3extbasebook:start>` |
+   :Versions:     `master (11-dev) <https://docs.typo3.org/m/typo3/book-extbasefluid/master/en-us/>`__ |
+                  `10.4 <https://docs.typo3.org/m/typo3/book-extbasefluid/10.4/en-us/>`__ |
                   `9.5 <https://docs.typo3.org/m/typo3/book-extbasefluid/9.5/en-us/>`__ |
                   `8.7 <https://docs.typo3.org/m/typo3/book-extbasefluid/8.7/en-us/>`__
    :Category:     Development
@@ -235,7 +234,8 @@ in the "Getting Started Tutorial". Developers should also look in the
    :Description:  Description
 
  - :Title:        :ref:`t3install:start`
-   :Versions:     :ref:`master (10.dev) <t3install:start>` |
+   :Versions:     `master (11-dev) <https://docs.typo3.org/m/typo3/guide-installation/master/en-us/>`__ |
+                  `10.4 <https://docs.typo3.org/m/typo3/guide-installation/10.4/en-us/>`__ |
                   `9.5 <https://docs.typo3.org/m/typo3/guide-installation/9.5/en-us/>`__ |
                   `8.7 <https://docs.typo3.org/m/typo3/guide-installation/8.7/en-us/>`__ |
                   `7.6 <https://docs.typo3.org/m/typo3/guide-installation/7.6/en-us/>`__

--- a/Documentation/Home/References.rst
+++ b/Documentation/Home/References.rst
@@ -21,7 +21,8 @@ depending on which task should be achieved.
    :Description:  Description
 
  - :Manual:       :ref:`TYPO3 Explained <t3coreapi:start>`
-   :Versions:     :ref:`master (10-dev) <t3coreapi:start>` |
+   :Versions:     `master (11-dev) <https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/>`__ |
+                  `10.4 <https://docs.typo3.org/m/typo3/reference-coreapi/10.4/en-us/>`__ |
                   `9.5 <https://docs.typo3.org/m/typo3/reference-coreapi/9.5/en-us/>`__ |
                   `8.7 <https://docs.typo3.org/m/typo3/reference-coreapi/8.7/en-us/>`__ |
                   `7.6 <https://docs.typo3.org/m/typo3/reference-coreapi/7.6/en-us/>`__
@@ -31,7 +32,8 @@ depending on which task should be achieved.
                   different target groups and outlined accordingly.
 
  - :Manual:       `Changelog <https://docs.typo3.org/c/typo3/cms-core/master/en-us/>`__
-   :Versions:     `master (10-dev) <https://docs.typo3.org/c/typo3/cms-core/master/en-us/>`__ |
+   :Versions:     `master (11-dev) <https://docs.typo3.org/c/typo3/cms-core/master/en-us/>`__ |
+                  `10.4 <https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog-10.html>`__ |
                   `9.5 <https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog-9.html>`__ |
                   `8.7 <https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog-8.html>`__ |
                   `7.6 <https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog-7.html>`__
@@ -46,7 +48,8 @@ depending on which task should be achieved.
    :Description:  Documentation of system extensions in the core.
 
  - :Manual:       :ref:`t3tca:start`
-   :Versions:     :ref:`master (10-dev) <t3tca:start>` |
+   :Versions:     `master (11-dev) <https://docs.typo3.org/m/typo3/reference-tca/master/en-us/>`__ |
+                  `10.4 <https://docs.typo3.org/m/typo3/reference-tca/10.4/en-us/>`__ |
                   `9.5 <https://docs.typo3.org/m/typo3/reference-tca/9.5/en-us/>`__ |
                   `8.7 <https://docs.typo3.org/m/typo3/reference-tca/8.7/en-us/>`__ |
                   `7.6 <https://docs.typo3.org/m/typo3/reference-tca/7.6/en-us/>`__
@@ -54,7 +57,8 @@ depending on which task should be achieved.
                   used to extend the definition of database tables.
 
  - :Manual:       :ref:`t3tsconfig:start`
-   :Versions:     :ref:`master (10-dev) <t3tsconfig:start>` |
+   :Versions:     `master (11-dev) <https://docs.typo3.org/m/typo3/reference-tsconfig/master/en-us/>`__ |
+                  `10.4 <https://docs.typo3.org/m/typo3/reference-tsconfig/10.4/en-us/>`__ |
                   `9.5 <https://docs.typo3.org/m/typo3/reference-tsconfig/9.5/en-us/>`__ |
                   `8.7 <https://docs.typo3.org/m/typo3/reference-tsconfig/8.7/en-us/>`__ |
                   `7.6 <https://docs.typo3.org/m/typo3/reference-tsconfig/7.6/en-us/>`__
@@ -62,7 +66,8 @@ depending on which task should be achieved.
                   to configure the backend.
 
  - :Manual:       :ref:`t3tsref:start`
-   :Versions:     :ref:`master (10-dev) <t3tsref:start>` |
+   :Versions:     `master (11-dev) <https://docs.typo3.org/m/typo3/reference-typoscript/master/en-us/>`__ |
+                  `10.4 <https://docs.typo3.org/m/typo3/reference-typoscript/10.4/en-us/>`__ |
                   `9.5 <https://docs.typo3.org/m/typo3/reference-typoscript/9.5/en-us/>`__ |
                   `8.7 <https://docs.typo3.org/m/typo3/reference-typoscript/8.7/en-us/>`__ |
                   `7.6 <https://docs.typo3.org/m/typo3/reference-typoscript/7.6/en-us/>`__
@@ -72,7 +77,7 @@ depending on which task should be achieved.
                   :ref:`TypoScript in 45 Minutes <t3ts45:start>` tutorial.
 
  - :Manual:       :ref:`t3viewhelper:start`
-   :Versions:     :ref:`master (10-dev) <t3viewhelper:start>` |
+   :Versions:     `master (10.4 + 11-dev) <https://docs.typo3.org/other/typo3/view-helper-reference/master/en-us/>`__ |
                   `9.5 <https://docs.typo3.org/other/typo3/view-helper-reference/9.5/en-us/>`__ |
                   `8.7 <https://docs.typo3.org/other/typo3/view-helper-reference/8.7/en-us/>`__
    :Description:  A complete reference of all available Fluid ViewHelper within
@@ -133,10 +138,10 @@ are listed here:
    :hidden:
 
 
-   TYPO3 Explained   <https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/>
+   TYPO3 Explained   <https://docs.typo3.org/m/typo3/reference-coreapi/10.4/en-us/>
    Core Changelog    <https://docs.typo3.org/c/typo3/cms-core/master/en-us/>
    SystemExtensions
-   TCA               <https://docs.typo3.org/m/typo3/reference-tca/master/en-us/>
-   TSconfig          <https://docs.typo3.org/m/typo3/reference-tsconfig/master/en-us/>
-   TypoScript        <https://docs.typo3.org/m/typo3/reference-typoscript/master/en-us/>
-   ViewHelper        <https://docs.typo3.org/other/typo3/view-helper-reference/master/en-us/>
+   TCA               <https://docs.typo3.org/m/typo3/reference-tca/10.4/en-us/>
+   TSconfig          <https://docs.typo3.org/m/typo3/reference-tsconfig/10.4/en-us/>
+   TypoScript        <https://docs.typo3.org/m/typo3/reference-typoscript/10.4/en-us/>
+   ViewHelper        <https://docs.typo3.org/other/typo3/view-helper-reference/10.4/en-us/>

--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -38,35 +38,32 @@ t3cheatsheets = https://docs.typo3.org/m/typo3/docs-cheatsheets/master/en-us/
 # currently does not work with "t3changelog:start" yet, because "start" label does not exist
 t3changelog   = https://docs.typo3.org/c/typo3/cms-core/master/en-us/
 t3contribute  = https://docs.typo3.org/m/typo3/guide-contributionworkflow/master/en-us/
-t3coreapi     = https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/
-t3editors     = https://docs.typo3.org/m/typo3/tutorial-editors/master/en-us/
+t3coreapi     = https://docs.typo3.org/m/typo3/reference-coreapi/10.4/en-us/
+t3editors     = https://docs.typo3.org/m/typo3/tutorial-editors/10.4/en-us/
 t3extexample  = https://docs.typo3.org/m/typo3/guide-example-extension-manual/master/en-us/
-# outdated!
-t3extbase     = https://docs.typo3.org/m/typo3/guide-extbasefluid/master/en-us/
-t3extbasebook  = https://docs.typo3.org/m/typo3/book-extbasefluid/master/en-us/
-t3install     = https://docs.typo3.org/m/typo3/guide-installation/master/en-us/
-t3l10n        = https://docs.typo3.org/m/typo3/guide-frontendlocalization/master/en-us/
-t3sitepackage = https://docs.typo3.org/m/typo3/tutorial-sitepackage/master/en-us/
-t3start       = https://docs.typo3.org/m/typo3/tutorial-getting-started/master/en-us/
-; !!! surf does not yet have a start label
-; see pending PR: https://github.com/TYPO3/Surf/pull/312
-t3surf        = https://docs.typo3.org/other/typo3/surf/master/en-us/
-t3tca         = https://docs.typo3.org/m/typo3/reference-tca/master/en-us/
-t3templating  = https://docs.typo3.org/m/typo3/tutorial-templating/master/en-us/
-t3ts45        = https://docs.typo3.org/m/typo3/tutorial-typoscript-in-45-minutes/master/en-us/
-t3tsconfig    = https://docs.typo3.org/m/typo3/reference-tsconfig/master/en-us/
-t3tsref       = https://docs.typo3.org/m/typo3/reference-typoscript/master/en-us/
+t3extbasebook = https://docs.typo3.org/m/typo3/book-extbasefluid/10.4/en-us/
+t3install     = https://docs.typo3.org/m/typo3/guide-installation/10.4/en-us/
+t3l10n        = https://docs.typo3.org/m/typo3/guide-frontendlocalization/10.4/en-us/
+t3sitepackage = https://docs.typo3.org/m/typo3/tutorial-sitepackage/10.4/en-us/
+t3start       = https://docs.typo3.org/m/typo3/tutorial-getting-started/10.4/en-us/
+t3tca         = https://docs.typo3.org/m/typo3/reference-tca/10.4/en-us/
+t3templating  = https://docs.typo3.org/m/typo3/tutorial-templating/10.4/en-us/
+t3ts45        = https://docs.typo3.org/m/typo3/tutorial-typoscript-in-45-minutes/10.4/en-us/
+t3tsconfig    = https://docs.typo3.org/m/typo3/reference-tsconfig/10.4/en-us/
+t3tsref       = https://docs.typo3.org/m/typo3/reference-typoscript/10.4/en-us/
 t3viewhelper  = https://docs.typo3.org/other/typo3/view-helper-reference/master/en-us/
 
 # sysext
 ckeditor      = https://docs.typo3.org/c/typo3/cms-rte-ckeditor/master/en-us/
 fsc           = https://docs.typo3.org/c/typo3/cms-fluid-styled-content/master/en-us/
 form          = https://docs.typo3.org/c/typo3/cms-form/master/en-us/
-# for linking to changelog, e.g. with :doc:`t3core:path`
-t3core        = https://docs.typo3.org/c/typo3/cms-core/master/en-us/
 
+; !!! surf does not yet have a start label
+; see pending PR: https://github.com/TYPO3/Surf/pull/312
+t3surf        = https://docs.typo3.org/other/typo3/surf/master/en-us/
 
 # outdated: should no longer be used as reference
+t3extbase     = https://docs.typo3.org/m/typo3/guide-extbasefluid/master/en-us/
 t3cgl         = https://docs.typo3.org/m/typo3/reference-coding-guidelines/master/en-us/
 t3fal         = https://docs.typo3.org/m/typo3/reference-fal/master/en-us/
 t3inside      = https://docs.typo3.org/m/typo3/reference-inside/master/en-us/


### PR DESCRIPTION
Manuals, Guides and References are branched off to 10.4 and can be linked.
System extensions will be updated once core branches off.
ViewHelper Reference is currently missing as well.

Relates: #145