### PR TITLE
Point ViewHelper Reference URLs to 10.4

### DIFF
--- a/Documentation/Home/References.rst
+++ b/Documentation/Home/References.rst
@@ -77,7 +77,8 @@ depending on which task should be achieved.
                   :ref:`TypoScript in 45 Minutes <t3ts45:start>` tutorial.
 
  - :Manual:       :ref:`t3viewhelper:start`
-   :Versions:     `master (10.4 + 11-dev) <https://docs.typo3.org/other/typo3/view-helper-reference/master/en-us/>`__ |
+   :Versions:     `master (11-dev) <https://docs.typo3.org/other/typo3/view-helper-reference/master/en-us/>`__ |
+                  `10.4 <https://docs.typo3.org/other/typo3/view-helper-reference/10.4/en-us/>`__ |
                   `9.5 <https://docs.typo3.org/other/typo3/view-helper-reference/9.5/en-us/>`__ |
                   `8.7 <https://docs.typo3.org/other/typo3/view-helper-reference/8.7/en-us/>`__
    :Description:  A complete reference of all available Fluid ViewHelper within

--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -51,7 +51,7 @@ t3templating  = https://docs.typo3.org/m/typo3/tutorial-templating/10.4/en-us/
 t3ts45        = https://docs.typo3.org/m/typo3/tutorial-typoscript-in-45-minutes/10.4/en-us/
 t3tsconfig    = https://docs.typo3.org/m/typo3/reference-tsconfig/10.4/en-us/
 t3tsref       = https://docs.typo3.org/m/typo3/reference-typoscript/10.4/en-us/
-t3viewhelper  = https://docs.typo3.org/other/typo3/view-helper-reference/master/en-us/
+t3viewhelper  = https://docs.typo3.org/other/typo3/view-helper-reference/10.4/en-us/
 
 # sysext
 ckeditor      = https://docs.typo3.org/c/typo3/cms-rte-ckeditor/master/en-us/


### PR DESCRIPTION
As it is now rendered and available, matching latest available LTS.