### PR TITLE
Remove snippets from menu

### DIFF
--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -194,6 +194,5 @@ you think can be improved.
    Home/WhatsNew
    Cheat Sheets                     <https://docs.typo3.org/m/typo3/docs-cheatsheets/master/en-us/>
    Tell Me Something About Topic X  <https://docs.typo3.org/typo3cms/TellMeSomethingAbout/>
-   Snippets                         <https://docs.typo3.org/typo3cms/Snippets/>
    Home/About/Index
    Home/Contribute


### PR DESCRIPTION
Snippets have the following problems:

* partly outdated
* no version branches
* no longer maintained

Related: TYPO3-Documentation/T3DocTeam#74
Related: https://decisions.typo3.org/t/what-to-do-with-the-snippets/591