### PR TITLE
Add link to TYPO3 Guidebook

### DIFF
--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -45,6 +45,11 @@ Support is available via StackOverflow and Slack. Visit the `help page
 For information about the different versions of TYPO3 and its system
 requirements, visit https://get.typo3.org.
 
+`The TYPO3 Guidebook: Understand and Use TYPO3 CMS
+<https://www.apress.com/gb/book/9781484265246>`__
+is available for purchase which provides a broad overview of the CMS, 
+and includes practical guides to get started including installing, 
+extending and troubleshooting.
 
 .. _how-the-documentation-is-organized:
 


### PR DESCRIPTION
Looking for feedback on the possibility of adding a link to the TYPO3 Guidebook somewhere in the official documentation. 

It might go here??

We are working on adding copies in to the TYPO3 Shop, so perhaps we'd like to wait until we can link to the shop rather than an external book seller. 