### PR TITLE
[TASK] Remove outdated link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,3 @@ Contents of the docs.typo3.org homepage and the "glue"-pages
 :Published:    https://docs.typo3.org/
 
 :Authors:      TYPO3 Documentation Team
-
-:How to:       `How to publish
-               <https://docs.typo3.org/typo3cms/RenderTYPO3DocumentationGuide/AtTheDocsServer/Administration/AboutTheHomepage/Index.html#manual-intervention-needed>`__
-


### PR DESCRIPTION
There is currently no public description of how the homepage repository is rendered. This dead link should be removed until there is such a description again.