### PR TITLE
Add information to sysext page

### DIFF
--- a/Documentation/Home/SystemExtensions.rst
+++ b/Documentation/Home/SystemExtensions.rst
@@ -14,7 +14,7 @@ extensions can be found in :file:`typo3/sysext` directory.
 Some of these extensions provide documentation, too. These are
 listed here.
 
-EXT:core, EXT:backend and other low level system extensions do not have their
+EXT:core, EXT:backend and other system extensions do not have their
 own documentation; the functionality is documented in
 :ref:`TYPO3 Explained <t3coreapi:start>`. For Extbase and Fluid, please see
 :ref:`Developing TYPO3 Extensions with Extbase and Fluid <t3extbasebook:start>`.

--- a/Documentation/Home/SystemExtensions.rst
+++ b/Documentation/Home/SystemExtensions.rst
@@ -14,6 +14,11 @@ extensions can be found in :file:`typo3/sysext` directory.
 Some of these extensions provide documentation, too. These are
 listed here.
 
+EXT:core, EXT:backend and other low level system extensions do not have their
+own documentation; the functionality is documented in
+:ref:`TYPO3 Explained <t3coreapi:start>`. For Extbase and Fluid, please see
+:ref:`Developing TYPO3 Extensions with Extbase and Fluid <t3extbasebook:start>`.
+
 .. toctree::
    :hidden:
 
@@ -96,7 +101,7 @@ part of the core and extracted at some point in time.
 
    - :Manual: `Redirects <https://docs.typo3.org/c/typo3/cms-redirects/master/en-us/>`_
      :ExtKey: redirects
-     :Comment: 
+     :Comment:
 
    - :Manual: `Integration of CKEditor as Rich Text Editor <https://docs.typo3.org/c/typo3/cms-rte-ckeditor/master/en-us/>`_
      :ExtKey: rte_ckeditor


### PR DESCRIPTION
Note: (not in commit): I separated a change from the other PR - because this is unrelated. I think this will make it easier to review and merge unrelated changes, especially since some things may be up for discussion.


---

The system extension page lists documentation for system extensions.
But documenation for the most important extensions is missing (e.g. core).

This may be confusing and irritating for beginners. We explain where to
find the information for core, backend etc. ("TYPO3 Explained"), and
also refer to the "Extbase / Fluid book" for extbase and fluid.