### PR TITLE
[TASK] Align with new TYPO3 documentation standards

### DIFF
--- a/Documentation/Home/About/News/2016/Index.rst
+++ b/Documentation/Home/About/News/2016/Index.rst
@@ -22,13 +22,13 @@ The ultimate explanation of optionSplit
 
 2016-12-28 by Martin Bless
 
-So you think you really understand what the TypoScript :ts:`optionSplit`
+So you think you really understand what the TypoScript :typoscript:`optionSplit`
 function does? Maybe, but better do a quick check:
-What is the result of :ts:`wrap = a|*|r|||||||*|z`?
-The wish to really understand :ts:`optionSplit` came up and in return
+What is the result of :typoscript:`wrap = a|*|r|||||||*|z`?
+The wish to really understand :typoscript:`optionSplit` came up and in return
 I reworked the :ref:`optionSplit chapter
 <t3tsref:objects-optionSplit>` in the :ref:`TypoScript reference <t3tsref:start>`.
-Hopefully it's the "ultimate explanation" of :ts:`optionSplit`.
+Hopefully it's the "ultimate explanation" of :typoscript:`optionSplit`.
 
 Is there something still missing?
 

--- a/Documentation/Home/About/News/2019/Index.rst
+++ b/Documentation/Home/About/News/2019/Index.rst
@@ -75,8 +75,8 @@ and extension programming in general.
 
 
 * There is an overview page with resources for developers in the
-  :ref:`Getting Started Tutorial <next-steps-developers>`
-* On that same page, there is a section "Fluid / Extbase"
+  :doc:`Getting Started Tutorial <t3start:Index>`.
+* On that same page, there is a section "Fluid / Extbase".
 
 
 The "Extbase / Fluid Guide" still contains the manually maintained Fluid ViewHelper

--- a/Documentation/Home/CreatingManagingContent.rst
+++ b/Documentation/Home/CreatingManagingContent.rst
@@ -77,7 +77,7 @@ Creating & Managing Content
 
          .. rst-class:: card-header h3
 
-            .. rubric:: :ref:`Forms <form:start>`
+            .. rubric:: :ref:`Forms <ext_form:start>`
 
          .. container:: card-body
 

--- a/Documentation/Home/OverviewInclude.rst.txt
+++ b/Documentation/Home/OverviewInclude.rst.txt
@@ -43,7 +43,7 @@ Getting Started with TYPO3
 
             *  :ref:`Editors Tutorial <t3editors:start>` explains the creation and management of pages and content.
 
-            *  :ref:`Form System Extension <form:quickstartEditors>` is a powerful
+            *  :ref:`Form System Extension <ext_form:quickstartEditors>` is a powerful
                tool that gives backend users the ability to create web forms.
 
             *  :ref:`Localization Guide <t3l10n:start>` covers everything needed to add additional languages to a
@@ -97,7 +97,7 @@ Getting Started with TYPO3
 
          .. rst-class:: card-header h3
 
-            .. rubric:: :ref:`Upgrading TYPO3 <t3upgrade>`
+            .. rubric:: :doc:`Upgrading TYPO3 <t3upgrade:Index>`
 
          .. container:: card-body
 

--- a/Documentation/Home/References.rst
+++ b/Documentation/Home/References.rst
@@ -37,7 +37,7 @@ Reference Manuals
 
          .. rst-class:: card-header
 
-            .. rubric:: :ref:`Changelog <t3changelog:Sitemap>`
+            .. rubric:: :ref:`Changelog <ext_core:Sitemap>`
 
          .. container:: card-body
 

--- a/Documentation/Includes.rst.txt
+++ b/Documentation/Includes.rst.txt
@@ -13,8 +13,6 @@
 .. role:: rst(code)
 .. role:: sep(strong)
 .. role:: sql(code)
-.. role:: ts(code)
-   :class: typoscript
 
 .. role:: tsconfig(code)
    :class: typoscript

--- a/Documentation/Includes.rst.txt
+++ b/Documentation/Includes.rst.txt
@@ -1,27 +1,36 @@
-﻿.. This is 'Includes.txt'. It is included at the very top of each and
-   every ReST source file in THIS documentation project (= manual).
+﻿.. More information about this file:
+   https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/GeneralConventions/FileStructure.html#includes-rst-txt
 
-.. role:: aspect (emphasis)
+.. ----------
+.. text roles
+.. ----------
 
+.. role:: aspect(emphasis)
+.. role:: bash(code)
 .. role:: html(code)
-   :language: html
-
 .. role:: js(code)
-   :language: javascript
-
-.. role:: jts(code)
-   :class: typescript
-   :language: typescript
-
 .. role:: php(code)
-   :language: php
+.. role:: rst(code)
+.. role:: sep(strong)
+.. role:: sql(code)
+.. role:: ts(code)
+   :class: typoscript
+
+.. role:: tsconfig(code)
+   :class: typoscript
 
 .. role:: typoscript(code)
-   :language: typoscript
+.. role:: xml(code)
+   :class: html
 
-.. role:: ts(typoscript)
-   :class: typoscript
-   :language: typoscript
+.. role:: yaml(code)
 
 .. default-role:: code
+
+.. ---------
+.. highlight
+.. ---------
+
+.. By default, code blocks use PHP syntax highlighting
+
 .. highlight:: php

--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -1,6 +1,6 @@
 ﻿.. include:: /Includes.rst.txt
-.. _start:
 
+.. _start:
 .. _examples:
 .. _guides:
 .. _tutorials:

--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -1,77 +1,68 @@
+# More information about this file:
+# https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/GeneralConventions/FileStructure.html#settings-cfg
+
 [general]
 
-project     = Welcome!
+project     = Homepage of docs.typo3.org
 version     = 2.0
-release     =
-t3author    = TYPO3 Documentation Team
-copyright   = since ever by the TYPO3 Documentation Team
-
-description = This manual comprises the contents of the docs.typo3.org
-   homepage and the "glue"-pages.
-
+release     = 2.0
+copyright   = since 2014 by the TYPO3 contributors
 
 [html_theme_options]
 
-; for theme t3SphinxThemeRtd and typo3_sphinx_theme
-
-github_branch        = main
-github_commit_hash   =
+# "Edit on GitHub" button
 github_repository    = TYPO3-Documentation/DocsTypo3Org-Homepage
-github_revision_msg  =
-github_sphinx_locale =
-project_contact      = https://typo3.org/community/teams/documentation/#c9886
-project_discussions  =
-project_home         =
-project_issues       = https://github.com/TYPO3-Documentation/DocsTypo3Org-Homepage/issues
+github_branch        = main
+
+# Footer links
+project_home         = https://docs.typo3.org
+project_contact      = https://typo3.slack.com/archives/C028JEPJL
 project_repository   = https://github.com/TYPO3-Documentation/DocsTypo3Org-Homepage
+project_issues       = https://github.com/TYPO3-Documentation/DocsTypo3Org-Homepage/issues
+project_discussions  =
+
 use_opensearch       =
 is_homepage          = yes
 
-
-
 [intersphinx_mapping]
 
-h2document    = https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/
-t3cheatsheets = https://docs.typo3.org/m/typo3/docs-cheatsheets/main/en-us/
-# currently does not work with "t3changelog:start" yet, because "start" label does not exist
-t3changelog   = https://docs.typo3.org/c/typo3/cms-core/main/en-us/
-t3contribute  = https://docs.typo3.org/m/typo3/guide-contributionworkflow/main/en-us/
-t3coreapi     = https://docs.typo3.org/m/typo3/reference-coreapi/11.5/en-us/
-t3editors     = https://docs.typo3.org/m/typo3/tutorial-editors/11.5/en-us/
-t3extexample  = https://docs.typo3.org/m/typo3/guide-example-extension-manual/main/en-us/
-t3extbasebook = https://docs.typo3.org/m/typo3/book-extbasefluid/11.5/en-us/
-t3l10n        = https://docs.typo3.org/m/typo3/guide-frontendlocalization/11.5/en-us/
-t3sitepackage = https://docs.typo3.org/m/typo3/tutorial-sitepackage/11.5/en-us/
-t3start       = https://docs.typo3.org/m/typo3/tutorial-getting-started/11.5/en-us/
-t3tca         = https://docs.typo3.org/m/typo3/reference-tca/11.5/en-us/
-t3templating  = https://docs.typo3.org/m/typo3/tutorial-templating/11.5/en-us/
-t3ts45        = https://docs.typo3.org/m/typo3/tutorial-typoscript-in-45-minutes/11.5/en-us/
-t3tsconfig    = https://docs.typo3.org/m/typo3/reference-tsconfig/11.5/en-us/
-t3tsref       = https://docs.typo3.org/m/typo3/reference-typoscript/11.5/en-us/
-t3viewhelper  = https://docs.typo3.org/other/typo3/view-helper-reference/11.5/en-us/
-t3upgrade     = https://docs.typo3.org/m/typo3/guide-installation/11.5/en-us/
+# Official TYPO3 manuals
+h2document     = https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/
+# t3cheatsheets  = https://docs.typo3.org/m/typo3/docs-cheatsheets/main/en-us/
+t3contribute   = https://docs.typo3.org/m/typo3/guide-contributionworkflow/main/en-us/
+t3coreapi      = https://docs.typo3.org/m/typo3/reference-coreapi/11.5/en-us/
+# t3docteam      = https://docs.typo3.org/m/typo3/team-t3docteam/main/en-us/
+t3editors      = https://docs.typo3.org/m/typo3/tutorial-editors/11.5/en-us/
+t3extbasebook  = https://docs.typo3.org/m/typo3/book-extbasefluid/11.5/en-us/
+# t3extexample   = https://docs.typo3.org/m/typo3/guide-example-extension-manual/main/en-us/
+# t3home         = https://docs.typo3.org/
+# t3install      = https://docs.typo3.org/m/typo3/guide-installation/main/en-us/
+t3l10n         = https://docs.typo3.org/m/typo3/guide-frontendlocalization/11.5/en-us/
+t3sitepackage  = https://docs.typo3.org/m/typo3/tutorial-sitepackage/11.5/en-us/
+t3start        = https://docs.typo3.org/m/typo3/tutorial-getting-started/11.5/en-us/
+t3tca          = https://docs.typo3.org/m/typo3/reference-tca/11.5/en-us/
+# t3templating   = https://docs.typo3.org/m/typo3/tutorial-templating/11.5/en-us/
+# t3translate    = https://docs.typo3.org/m/typo3/guide-frontendlocalization/main/en-us/
+t3tsconfig     = https://docs.typo3.org/m/typo3/reference-tsconfig/11.5/en-us/
+t3tsref        = https://docs.typo3.org/m/typo3/reference-typoscript/11.5/en-us/
+t3ts45         = https://docs.typo3.org/m/typo3/tutorial-typoscript-in-45-minutes/11.5/en-us/
+t3viewhelper   = https://docs.typo3.org/other/typo3/view-helper-reference/11.5/en-us/
+t3upgrade      = https://docs.typo3.org/m/typo3/guide-installation/11.5/en-us/
 
-# sysext
-ckeditor      = https://docs.typo3.org/c/typo3/cms-rte-ckeditor/main/en-us/
-fsc           = https://docs.typo3.org/c/typo3/cms-fluid-styled-content/main/en-us/
-form          = https://docs.typo3.org/c/typo3/cms-form/main/en-us/
+# TYPO3 system extensions
+# ext_adminpanel     = https://docs.typo3.org/c/typo3/cms-adminpanel/main/en-us/
+ext_core           = https://docs.typo3.org/c/typo3/cms-core/main/en-us/
+# ext_dashboard      = https://docs.typo3.org/c/typo3/cms-dashboard/main/en-us/
+# ext_felogin        = https://docs.typo3.org/c/typo3/cms-felogin/main/en-us/
+ext_form           = https://docs.typo3.org/c/typo3/cms-form/main/en-us/
+# ext_fsc            = https://docs.typo3.org/c/typo3/cms-fluid-styled-content/main/en-us/
+# ext_indexed_search = https://docs.typo3.org/c/typo3/cms-indexed-search/main/en-us/
+# ext_rte_ckeditor   = https://docs.typo3.org/c/typo3/cms-rte-ckeditor/main/en-us/
+# ext_scheduler      = https://docs.typo3.org/c/typo3/cms-scheduler/main/en-us/
+# ext_seo            = https://docs.typo3.org/c/typo3/cms-seo/main/en-us/
+# ext_workspaces     = https://docs.typo3.org/c/typo3/cms-workspaces/main/en-us/
 
-; !!! surf does not yet have a start label
-; see pending PR: https://github.com/TYPO3/Surf/pull/312
-t3surf        = https://docs.typo3.org/other/typo3/surf/main/en-us/
-
-# outdated: should no longer be used as reference
-t3extbase     = https://docs.typo3.org/m/typo3/guide-extbasefluid/main/en-us/
-
-# t3cgl - doesn't exist any more
-# t3cgl         = https://docs.typo3.org/m/typo3/reference-coding-guidelines/master/en-us/
-
+# Outdated
 t3fal         = https://docs.typo3.org/m/typo3/reference-fal/main/en-us/
 t3inside      = https://docs.typo3.org/m/typo3/reference-inside/main/en-us/
-t3security    = https://docs.typo3.org/m/typo3/guide-security/main/en-us/
 t3services    = https://docs.typo3.org/m/typo3/reference-services/main/en-us/
-t3skinning    = https://docs.typo3.org/m/typo3/reference-skinning/main/en-us/
-
-# t3tssyntax - doesn't exist any more
-# t3tssyntax    = https://docs.typo3.org/m/typo3/reference-typoscript-syntax/master/en-us/
-

--- a/README.rst
+++ b/README.rst
@@ -1,9 +1,8 @@
-============================================================
-Contents of the docs.typo3.org homepage and the "glue"-pages
-============================================================
+==========================
+Homepage of docs.typo3.org
+==========================
 
-:Repository:   https://github.com/TYPO3-Documentation/DocsTypo3Org-Homepage
+This documentation covers the content of the docs.typo3.org homepage and the "glue" pages.
 
-:Published:    https://docs.typo3.org/
-
-:Authors:      TYPO3 Documentation Team
+:Repository:  https://github.com/TYPO3-Documentation/DocsTypo3Org-Homepage
+:Read online: https://docs.typo3.org/


### PR DESCRIPTION
- align README.rst, Settings.cfg, Index.rst, Includes.rst.txt
- align intersphinx mapping names
- fix most rendering warnings

See https://github.com/TYPO3-Documentation/TYPO3CMS-Guide-HowToDocument/commit/c2bb63beadb7cc1ea6eb3496613c3376f970d4c9 for further details.

Relates: https://github.com/TYPO3-Documentation/T3DocTeam/issues/181