### PR TITLE
[DOCS] Reference manual's start page with :doc:`<manual>:Index`

### DIFF
--- a/Documentation/Home/About/News/2016/Index.rst
+++ b/Documentation/Home/About/News/2016/Index.rst
@@ -27,7 +27,7 @@ function does? Maybe, but better do a quick check:
 What is the result of :typoscript:`wrap = a|*|r|||||||*|z`?
 The wish to really understand :typoscript:`optionSplit` came up and in return
 I reworked the :ref:`optionSplit chapter
-<t3tsref:objects-optionSplit>` in the :ref:`TypoScript reference <t3tsref:start>`.
+<t3tsref:objects-optionSplit>` in the :doc:`TypoScript reference <t3tsref:Index>`.
 Hopefully it's the "ultimate explanation" of :typoscript:`optionSplit`.
 
 Is there something still missing?
@@ -41,7 +41,7 @@ The FAL Reference has landed
 
 2016-11-18 by François Suter
 
-Until recently the :ref:`File Abstraction Layer Reference <t3fal:start>` was
+Until recently the :doc:`File Abstraction Layer Reference <t3fal:Index>` was
 pretty much an empty husk and users had to rely on a wiki page which was
 not always up to date.
 
@@ -113,7 +113,7 @@ TYPO3 Frontend Localization Guide updated
 
 2016-10-05 by Francois Suter
 
-The :ref:`TYPO3 Frontend Localization Guide <t3l10n:start>` manual
+The :doc:`TYPO3 Frontend Localization Guide <t3l10n:Index>` manual
 was purged of many of its old parts this spring by Christopher,
 but still remained out of date, in particular with regards to screenshots.
 It is now fully up to date again for TYPO3 7. It is also restructured,
@@ -171,7 +171,7 @@ TYPO3 Services Reference updated and expanded
 
 2016-09-07 by Francois Suter
 
-The :ref:`TYPO3 Services References <t3services:start>` manual is finally up to date again
+The :doc:`TYPO3 Services References <t3services:Index>` manual is finally up to date again
 (for TYPO3 CMS 7). What's more it contains a whole new chapter
 about authentication services. This chapter also describes the
 TYPO3 CMS authentication process on a very general level, the
@@ -210,7 +210,7 @@ Inside TYPO3 updated
 
 2016-08-05 by Francois Suter
 
-The :ref:`Inside TYPO3 Reference <t3inside:start>`
+The :doc:`Inside TYPO3 Reference <t3inside:Index>`
 is finally up to date for TYPO3 CMS 7. A lot of content was fully
 rewritten, while many obsolete parts were removed.
 

--- a/Documentation/Home/About/News/2017/Index.rst
+++ b/Documentation/Home/About/News/2017/Index.rst
@@ -62,7 +62,7 @@ TCA Reference overhaul
 
 2017-03-14 by Christian Kuhn
 
-The :ref:`TCA Reference <t3tca:start>` got a major overhaul and should be ready for TYPO3 v8 LTS now.
+The :doc:`TCA Reference <t3tca:Index>` got a major overhaul and should be ready for TYPO3 v8 LTS now.
 
 
 
@@ -81,7 +81,7 @@ The FormEngine code construct of the core has been refactored since version 6.2
 and is much more flexible in version 7 LTS and 8 LTS.
 
 An overview of the :ref:`FormEngine API <t3coreapi:FormEngine>` has now been added
-to :ref:`TYPO3 API documentation <t3coreapi:start>`.
+to :doc:`TYPO3 API documentation <t3coreapi:Index>`.
 
 **Contribute:** Don't hesitate to use the "Edit me on Github" button
 to improve the documentation.

--- a/Documentation/Home/About/News/2018/Index.rst
+++ b/Documentation/Home/About/News/2018/Index.rst
@@ -62,10 +62,10 @@ TYPO3 Explained and more
 
 Our ongoing efforts to integrate, streamline, simplify, modernize and structure the main
 TYPO3 Core documents reached a next level: The well known "Core API" has been renamed to
-:ref:`TYPO3 Explained <t3coreapi:start>`: This document gained more and more aspects over time
+:doc:`TYPO3 Explained <t3coreapi:Index>`: This document gained more and more aspects over time
 and many different ones have been merged into it. This has advantages for everyone:
 
-* One main entry point: :ref:`TYPO3 Explained <t3coreapi:start>` becomes *the* main document where
+* One main entry point: :doc:`TYPO3 Explained <t3coreapi:Index>` becomes *the* main document where
   all main aspects of the TYPO3 Core can be found. You are getting less confused by all the existing
   other documents and references, TYPO3 Explained is *the* main thing to look at.
 
@@ -82,7 +82,7 @@ and many different ones have been merged into it. This has advantages for everyo
 * Less duplication: We already streamlined at least four places where the main filesystem structure
   of the system has been explained. All in different documents. There are probably more places. This
   is true for other topics, too. And none of them is the real source of truth. Integrating repositories
-  into :ref:`TYPO3 Explained <t3coreapi:start>` gives us the opportunity to merge this stuff around and
+  into :doc:`TYPO3 Explained <t3coreapi:Index>` gives us the opportunity to merge this stuff around and
   streamline it once and for all. If we then maintain this stuff, it happens at one place and one place only.
 
 How does all that materialize? Here are some of the works that happened already, with more
@@ -100,7 +100,7 @@ on the list:
   :ref:`XML Site map <t3coreapi:xmlsitemap>` have been documented. Thanks to Richard Haeser for this
   incredible work!
 
-* All added / changed properties of v9 are reflected in :ref:`TYPO3 Explained <t3coreapi:start>` and
+* All added / changed properties of v9 are reflected in :doc:`TYPO3 Explained <t3coreapi:Index>` and
   the reference documents already. Our workflow to review the `Changelog files
   <https://docs.typo3.org/typo3cms/extensions/core/latest/>`_ and merge relevant parts directly
   works out great. Special thanks to Anja Leichsenring for her continued efforts in this area!
@@ -114,7 +114,7 @@ on the list:
 
 * The :ref:`Coding Guidelines chapter <t3coreapi:cgl>` of TYPO3 Explained got major additions by Sybille
   Peters. She is active in the documentation area at various places and for instance continuously
-  improves the :ref:`Contribution workflow <t3contribute:start>` document. Thanks a ton for this!
+  improves the :doc:`Contribution workflow <t3contribute:Index>` document. Thanks a ton for this!
 
 * We see an increasing number of persons changing details of the documentation all over the place, too
   many to mention in person. This is great! We try our best to review pull requests in time and
@@ -251,14 +251,14 @@ We modernized some of the main TYPO3 core documents with more than 100
 single commits the last days:
 
 * The old "Inside TYPO3" document is gone and all information has been merged into the
-  :ref:`TYPO3 Core API <t3coreapi:start>`. The Core API document more and more evolves
+  :doc:`TYPO3 Core API <t3coreapi:Index>`. The Core API document more and more evolves
   into **the** TYPO3 core documentation compendium where all conceptual core related
   information should be looked up in. The term "Core API" will probably change at
   some point to reflect this, too.
 
-* The :ref:`t3tsconfig:start` received a major overhaul. This document
+* The :doc:`t3tsconfig:Index` received a major overhaul. This document
   is one of the most important documents next to the other two references, namely the
-  :ref:`t3tsref:start` and the :ref:`TCA Reference <t3tca:start>`.
+  :doc:`t3tsref:Index` and the :doc:`TCA Reference <t3tca:Index>`.
   The TSconfig Reference didn't receive too much love within the last years, but now it comes with
   a reworked menu structure, a lot of streamlined information and a simplified property listing
   with more examples. Various chapters have been moved around between the main core documents

--- a/Documentation/Home/About/News/2019/Index.rst
+++ b/Documentation/Home/About/News/2019/Index.rst
@@ -129,7 +129,7 @@ Some more changes were made to make it easier for people new to TYPO3
 to find their way around the documentation:
 
 * The tips on the start page used to address advanced documentation
-  contribution. This has now been moved to :ref:`h2document:start` and
+  contribution. This has now been moved to :doc:`h2document:Index` and
   more basic tips about TYPO3 and the documentation added, see
   `start page <https://docs.typo3.org>`__. This includes for example a
   link to the `help page on typo3.org <https://typo3.org/help>`__.
@@ -163,7 +163,7 @@ Thanks goes to Sybille Peters
 2019-05-09 by Sybille Peters
 
 
-The :ref:`t3start:start` was updated for TYPO3 9.5.
+The :doc:`t3start:Index` was updated for TYPO3 9.5.
 
 Additionally, some more improvements were made:
 
@@ -199,7 +199,7 @@ or find out which of the information was relevant and up to date.
 Because of this, we made several improvements.
 
 These include additional chapters to the
-manual :ref:`h2document:start` to help you get started, such as:
+manual :doc:`h2document:Index` to help you get started, such as:
 
 * :ref:`h2document:docs-contribute` : Main entry point for information about
   contributing and a walkthrough of editing with GitHub.
@@ -325,7 +325,7 @@ The community is invited to participate in enhancing it:
   to ask questions (`Register <https://my.typo3.org/index.php?id=35>`__)
 * Click "Edit me on GitHub" in the top right corner to make small changes
   (`Find out more ... <https://docs.typo3.org/typo3cms/HowToDocument/WritingDocsOfficial/Index.html>`__)
-  or follow the :ref:`t3contribute:start`
+  or follow the :doc:`t3contribute:Index`
 
 
 .. rst-class:: horizbuttons-primary-m clear-both

--- a/Documentation/Home/About/News/2020/Index.rst
+++ b/Documentation/Home/About/News/2020/Index.rst
@@ -19,7 +19,7 @@
 
 *2020-07-11 by Sybille Peters*
 
-The menu of :ref:`t3coreapi:start` was considerably changed during and after
+The menu of :doc:`t3coreapi:Index` was considerably changed during and after
 the Initiatives Week 2020.
 
 The main goal was to make it easier to find and jump to a general topic.
@@ -170,7 +170,7 @@ Fluid as was the case when it was initially introduced.
 
 As **next steps** the documentation could be further restructured, moving
 for example general Fluid information that is not specific to Extbase /
-Fluid from the :ref:`t3extbasebook:start` to "TYPO3 Explained".
+Fluid from the :doc:`t3extbasebook:Index` to "TYPO3 Explained".
 
 .. _news-2020-tsref:
 .. rst-class:: panel panel-default
@@ -180,7 +180,7 @@ TypoScript Reference
 
 *2020-01-26*
 
-We made several changes to the :ref:`TypoScript reference <t3tsref:start>` and documentation for the
+We made several changes to the :doc:`TypoScript reference <t3tsref:Index>` and documentation for the
 topic TypoScript in general.
 
 **Summary**

--- a/Documentation/Home/About/UsingThisSite/Index.rst
+++ b/Documentation/Home/About/UsingThisSite/Index.rst
@@ -16,7 +16,7 @@ The page you are currently reading is part of a few start pages we call **"glue 
 From here, everything else is linked. The entire documentation is built out of individual
 **"manuals"**. This can be an extension manual like
 `ext:form <https://docs.typo3.org/typo3cms/extensions/form/latest/>`__ or a tutorial
-like :ref:`t3start:start`.
+like :doc:`t3start:Index`.
 
 You can regard the "glue pages" as a special top-level manual which is used for information,
 orientation and navigation.
@@ -28,7 +28,7 @@ The "glue pages" **contain**:
 
 * the start page https://docs.typo3.org
 * :ref:`tutorials`: A list of tutorials and guides
-* :ref:`references`: A list of core documentation manuals, including :ref:`t3coreapi:start`
+* :ref:`references`: A list of core documentation manuals, including :doc:`t3coreapi:Index`
   and several references.
 * this page and the entire :ref:`about-documentation` section
 * ...
@@ -56,7 +56,7 @@ or :ref:`extensions` to go to the documentation of an extension.
 Menu of other manuals
 ---------------------
 
-As soon as you go to a manual (e.g. :ref:`t3start:start`), you leave the "glue pages"
+As soon as you go to a manual (e.g. :doc:`t3start:Index`), you leave the "glue pages"
 and the menu will look different:
 
 * **On a glue page**: Menu of "glue pages", no search field
@@ -108,7 +108,7 @@ go to the start page of the manual by clicking on the title of the manual
 Version selector
 ================
 
-When you are reading a manual, for example the :ref:`t3start:start`, you can select
+When you are reading a manual, for example the :doc:`t3start:Index`, you can select
 a version from the version selector (which is located under the title).
 
 The version usually reflects the TYPO3 version, so for example
@@ -129,7 +129,7 @@ Search
 ======
 
 The search box only searches in the selected manual. For example, if you are
-reading :ref:`t3start:start`, then search will only search within this manual.
+reading :doc:`t3start:Index`, then search will only search within this manual.
 
 Alternatively, you can use an external search engine:
 

--- a/Documentation/Home/ConfiguringTYPO3.rst
+++ b/Documentation/Home/ConfiguringTYPO3.rst
@@ -39,7 +39,7 @@ Configuring TYPO3
 
          .. rst-class:: card-header h3
 
-            .. rubric:: :ref:`TypoScript in 45 Minutes <t3ts45:start>`
+            .. rubric:: :doc:`TypoScript in 45 Minutes <t3ts45:Index>`
 
          .. container:: card-body
 

--- a/Documentation/Home/CreatingManagingContent.rst
+++ b/Documentation/Home/CreatingManagingContent.rst
@@ -57,7 +57,7 @@ Creating & Managing Content
 
          .. rst-class:: card-header h3
 
-            .. rubric:: :ref:`Localizing Pages & Content <t3l10n:start>`
+            .. rubric:: :doc:`Localizing Pages & Content <t3l10n:Index>`
 
          .. container:: card-body
 
@@ -77,7 +77,7 @@ Creating & Managing Content
 
          .. rst-class:: card-header h3
 
-            .. rubric:: :ref:`Forms <ext_form:start>`
+            .. rubric:: :doc:`Forms <ext_form:Index>`
 
          .. container:: card-body
 

--- a/Documentation/Home/ExtensionManuals.rst
+++ b/Documentation/Home/ExtensionManuals.rst
@@ -36,7 +36,7 @@ Extension Development
 
             *  :ref:`t3coreapi:extension-naming` and :ref:`t3coreapi:cgl`
 
-            * :ref:`t3extbasebook:start`
+            * :doc:`t3extbasebook:Index`
 
 
    .. container:: col-md-6 pl-0 pr-3 py-3 m-0

--- a/Documentation/Home/OverviewInclude.rst.txt
+++ b/Documentation/Home/OverviewInclude.rst.txt
@@ -41,12 +41,12 @@ Getting Started with TYPO3
 
          .. container:: card-body
 
-            *  :ref:`Editors Tutorial <t3editors:start>` explains the creation and management of pages and content.
+            *  :doc:`Editors Tutorial <t3editors:Index>` explains the creation and management of pages and content.
 
             *  :ref:`Form System Extension <ext_form:quickstartEditors>` is a powerful
                tool that gives backend users the ability to create web forms.
 
-            *  :ref:`Localization Guide <t3l10n:start>` covers everything needed to add additional languages to a
+            *  :doc:`Localization Guide <t3l10n:Index>` covers everything needed to add additional languages to a
                TYPO3 site, and how to translate content and pages.
 
 
@@ -65,7 +65,7 @@ Getting Started with TYPO3
             *  :ref:`Fluid is TYPO3’s templating engine. <t3coreapi:fluid>`
                Fluid acts as the glue between your static HTML templates and the content you create in TYPO3’s backend.
 
-            * :ref:`Sitepackages <t3sitepackage:start>` allow you to bundle your Fluid templates and other site assets into a single, reusable extension.
+            * :doc:`Sitepackages <t3sitepackage:Index>` allow you to bundle your Fluid templates and other site assets into a single, reusable extension.
 
    .. _start-configuration:
 
@@ -80,7 +80,7 @@ Getting Started with TYPO3
          .. container:: card-body
 
             The :ref:`configuration overview <t3coreapi:config-overview>`
-            in :ref:`TYPO3 Explained <t3coreapi:start>`
+            in :doc:`TYPO3 Explained <t3coreapi:Index>`
             gives an overview of the various configuration options available.
             It contains a description of the main system configuration options.
 
@@ -141,7 +141,7 @@ Getting Started with TYPO3
 
          .. container:: card-body
 
-            *  :ref:`TYPO3 Explained <t3coreapi:start>` contains detailed information
+            *  :doc:`TYPO3 Explained <t3coreapi:Index>` contains detailed information
                about concepts and APIs for core and extension developers.
 
             *  The `Core changelog <https://docs.typo3.org/c/typo3/cms-core/master/en-us/>`__
@@ -164,7 +164,7 @@ Getting Started with TYPO3
 
             *Internationalization* | *Translation* | *Multiple Languages*
 
-            *  :ref:`Localization Guide <t3l10n:start>`
+            *  :doc:`Localization Guide <t3l10n:Index>`
 
             *  :ref:`Supported languages <t3coreapi:i18n_languages>`
 

--- a/Documentation/Home/References.rst
+++ b/Documentation/Home/References.rst
@@ -15,7 +15,7 @@ Reference Manuals
 
          .. rst-class:: card-header
 
-            .. rubric:: :ref:`t3coreapi:start`
+            .. rubric:: :doc:`t3coreapi:Index`
 
          .. container:: card-body
 
@@ -56,7 +56,7 @@ Reference Manuals
 
          .. rst-class:: card-header
 
-            .. rubric:: :ref:`t3tca:start`
+            .. rubric:: :doc:`t3tca:Index`
 
          .. container:: card-body
 
@@ -77,7 +77,7 @@ Reference Manuals
 
          .. rst-class:: card-header
 
-            .. rubric:: :ref:`t3tsconfig:start`
+            .. rubric:: :doc:`t3tsconfig:Index`
 
          .. container:: card-body
 
@@ -101,14 +101,14 @@ Reference Manuals
 
          .. rst-class:: card-header
 
-            .. rubric:: :ref:`t3tsref:start`
+            .. rubric:: :doc:`t3tsref:Index`
 
          .. container:: card-body
 
             TypoScript is a configuration language that is specific to
             TYPO3. This is used to configure the frontend.
             For an introduction see the
-            :ref:`TypoScript in 45 Minutes <t3ts45:start>` tutorial.
+            :doc:`TypoScript in 45 Minutes <t3ts45:Index>` tutorial.
 
          .. container:: card-footer pb-0
 
@@ -125,7 +125,7 @@ Reference Manuals
 
          .. rst-class:: card-header
 
-            .. rubric:: :ref:`t3viewhelper:start`
+            .. rubric:: :doc:`t3viewhelper:Index`
 
          .. container:: card-body
 
@@ -154,7 +154,7 @@ Reference Manuals
 With our ongoing consolidation efforts, some documents have been merged into other documents
 for better overview, less duplication and confusion. The latest versions (since TYPO3 9.5) of
 these documents only show a "Has been moved" message. The information has been moved to
-:ref:`t3coreapi:start`.
+:doc:`t3coreapi:Index`.
 
 In case information for older TYPO3 versions (8.7 and below) is required, the obsoleted documents
 are listed here:
@@ -168,7 +168,7 @@ are listed here:
  - :Manual:        Inside TYPO3
                    `8.7 <https://docs.typo3.org/m/typo3/reference-inside/8.7/en-us/>`__ |
                    `7.6 <https://docs.typo3.org/m/typo3/reference-inside/7.6/en-us/>`__
-   :Description:   Outdated. Core v9 version and above have been integrated into :ref:`t3coreapi:start`
+   :Description:   Outdated. Core v9 version and above have been integrated into :doc:`t3coreapi:Index`
 
  - :Manual:        Core Coding Guidelines
    :Description:   Outdated. **All versions** have been integrated into :ref:`t3coreapi:cgl` (TYPO3 Explained)

--- a/Documentation/Home/SystemExtensions.rst
+++ b/Documentation/Home/SystemExtensions.rst
@@ -16,8 +16,8 @@ listed here.
 
 EXT:core, EXT:backend and other system extensions do not have their
 own documentation; the functionality is documented in
-:ref:`TYPO3 Explained <t3coreapi:start>`. For Extbase and Fluid, please see
-:ref:`Developing TYPO3 Extensions with Extbase and Fluid <t3extbasebook:start>`.
+:doc:`TYPO3 Explained <t3coreapi:Index>`. For Extbase and Fluid, please see
+:doc:`Developing TYPO3 Extensions with Extbase and Fluid <t3extbasebook:Index>`.
 
 .. toctree::
    :hidden:

--- a/Documentation/Home/Templating.rst
+++ b/Documentation/Home/Templating.rst
@@ -39,7 +39,7 @@ Templating
 
          .. rst-class:: card-header
 
-            .. rubric:: :ref:`Sitepackages <t3sitepackage:start>`
+            .. rubric:: :doc:`Sitepackages <t3sitepackage:Index>`
 
          .. container:: card-body
 


### PR DESCRIPTION
Relates: https://github.com/TYPO3-Documentation/T3DocTeam/issues/185