### PR TITLE
Move extension manuals search to separate page

### DIFF
--- a/Documentation/Home/ExtensionManuals.rst
+++ b/Documentation/Home/ExtensionManuals.rst
@@ -1,18 +1,8 @@
-:template: extensions.html
-
 .. _extensions:
 
 =============================
 Developing & Using Extensions
 =============================
-
-.. ATTENTION:
-   Be careful with this special folder /typo3cms/extensions !!!
-
-.. Note the special template 'extensions.html' (see beginning of this file)
-
-.. First
-   You may add normal rst content here.
 
 Extension Development
 =====================
@@ -87,27 +77,13 @@ Extension Manuals
          .. container:: card-body
 
             Third party extensions are available through the
-            `TYPO3 Extension Repository (TER) <https://extensions.typo3.org/>`__ or via composer.
+            TYPO3 Extension Repository (TER) or via composer.
 
-            **Use the form below to search by extension keys.**
+            Go to the `TYPO3 Extension Repository (TER) <https://extensions.typo3.org/>`__ to search
+            for documentation of third party extensions.
 
-Extension Manual Search
-=======================
+            The legacy :ref:`Extension manual search <extensionsManualSearch>` is still available.
 
-.. Second:
-   Don't do anything more!
-   Template 'extensions.html' will insert the necessary
-   javascript and html to render the extension selection
-   form here.
-
-.. How does it work?
-   This document has the file-wide-metadata field 'template'
-   set to 'extensions.html'. So this document will use the
-   template 'extensions.html' for rendering instead of the
-   usual 'page.html' of normal pages.
-   The logic for this is in __init__.py of t3SphinxThemeRtd,
-   which is not only a theme but is loaded as Sphinx extension
-   as well.
 
 .. toctree::
    :hidden:
@@ -115,4 +91,4 @@ Extension Manual Search
    Extension Development Basics <https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/ExtensionArchitecture/Index.html>
    Extensions with Extbase & Fluid <https://docs.typo3.org/m/typo3/book-extbasefluid/master/en-us/>
    SystemExtensions
-   Extension Manuals  <https://docs.typo3.org/Home/ExtensionManuals.html#extension-manual-search>
+   Third party extensions <https://extensions.typo3.org/>

--- a/Documentation/Home/ExtensionManualsSearch.rst
+++ b/Documentation/Home/ExtensionManualsSearch.rst
@@ -1,0 +1,42 @@
+:template: extensions.html
+
+.. _extensionsManualSearch:
+
+=======================
+Extension manual search
+=======================
+
+.. ATTENTION:
+   Be careful with this special folder /typo3cms/extensions !!!
+
+.. Note the special template 'extensions.html' (see beginning of this file)
+
+.. First
+   You may add normal rst content here.
+
+Search for documentation of third party extensions on docs.typo3.org.
+
+.. important::
+
+   The search results only contain documentation for third party extensions rendered on docs.typo3.org.
+
+   It does not
+
+   *  show documentation for third party extensions which are **not** rendered on docs.typo3.org
+   *  show documentation for system extensions
+
+
+.. Second:
+   Don't do anything more!
+   Template 'extensions.html' will insert the necessary
+   javascript and html to render the extension selection
+   form here.
+
+.. How does it work?
+   This document has the file-wide-metadata field 'template'
+   set to 'extensions.html'. So this document will use the
+   template 'extensions.html' for rendering instead of the
+   usual 'page.html' of normal pages.
+   The logic for this is in __init__.py of t3SphinxThemeRtd,
+   which is not only a theme but is loaded as Sphinx extension
+   as well.


### PR DESCRIPTION
This moves the extension manuals search to a separate page and
thus fixes the problem with the automatic scrolling on that page.

Additionally, information is added about what the Extension Manual
Search will find and what it will not find.

Also, this patch makes the extension manual search a little less
prominent and propagates searching on extensions.typo3.org.

Both have their pros and cons, but it is very confusing for the
user to have to know if an extension provides documentation on
docs.typo3.org and currently many extensions do not.

The extension manuals search on docs.typo3.org had some drawbacks:

- automatic scrolling of extension page
- only third party extensions are shown which are rendered on
  docs.typo3.org (see above)
- in some cases, the results may be incorrect (see issues)

Unfortunately, we currently have no way to obtain a full list of all extension docs:

- the Extension Manual Search only shows extension rendered on docs.typo3.org
  (and no system extensions)
- the search on extensions.typo3.org only shows extensions registered on
  extensions.typo3.org and no system extensions

Resolves: #193
Related: #192
Related: #155