### PR TITLE
[FEATURE] Add "Document an extension" to the extensions chapter

### DIFF
--- a/Documentation/Home/ExtensionManuals.rst
+++ b/Documentation/Home/ExtensionManuals.rst
@@ -42,7 +42,7 @@ Extension Development
             *  :ref:`t3coreapi:request-handling`
 
 Extension Manuals
-==================
+=================
 
 .. container:: row m-0 p-0
 
@@ -56,7 +56,7 @@ Extension Manuals
 
          .. container:: card-body
 
-            Here you can find documentation of system extensions and third party extensions,
+            Here you can find documentation of system extensions and third-party extensions,
             if available.
 
             System extensions are shipped with the TYPO3 core. A list of all available
@@ -74,13 +74,28 @@ Extension Manuals
 
          .. container:: card-body
 
-            Third party extensions are available through the
+            Third-party extensions are available through the
             TYPO3 Extension Repository (TER) or via composer.
 
             Go to the `TYPO3 Extension Repository (TER) <https://extensions.typo3.org/>`__ to search
-            for documentation of third party extensions.
+            for documentation of third-party extensions.
 
             The legacy :ref:`Extension manual search <extensionsManualSearch>` is still available.
+
+   .. container:: col-md-6 pl-0 pr-3 py-3 m-0
+
+      .. container:: card px-0 h-100
+
+         .. rst-class:: card-header
+
+            .. rubric:: Document an extension
+
+         .. container:: card-body
+
+            Documentation is an essential part of an extension.
+            Learn :ref:`how to document <how-to-start-docs-extension>` an extension
+            and :ref:`publish the documentation <register-for-rendering>` on docs.typo3.org.
+
 
 
 .. toctree::
@@ -88,4 +103,5 @@ Extension Manuals
 
    Extension Development Basics <https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ExtensionArchitecture/Index.html>
    SystemExtensions
-   Third party extensions <https://extensions.typo3.org/>
+   Third-party extensions <https://extensions.typo3.org/>
+   Document an extension <https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/WritingDocForExtension/Index.html>


### PR DESCRIPTION
This makes the documentation about "How to document an extension" more accessible. Just click the main navigation item or follow the links on the cards.