### PR TITLE
[TASK] Use v12 as reference for EXT:sys_note

### DIFF
--- a/Documentation/Home/SystemExtensions.rst
+++ b/Documentation/Home/SystemExtensions.rst
@@ -37,7 +37,7 @@ own documentation; the functionality is documented in
    rte_ckeditor         <https://docs.typo3.org/c/typo3/cms-rte-ckeditor/12.4/en-us/>
    scheduler            <https://docs.typo3.org/c/typo3/cms-scheduler/12.4/en-us/>
    seo                  <https://docs.typo3.org/c/typo3/cms-seo/12.4/en-us/>
-   sys_note             <https://docs.typo3.org/c/typo3/cms-sys-note/main/en-us/>
+   sys_note             <https://docs.typo3.org/c/typo3/cms-sys-note/12.4/en-us/>
    t3editor             <https://docs.typo3.org/c/typo3/cms-t3editor/12.4/en-us/>
    workspaces           <https://docs.typo3.org/c/typo3/cms-workspaces/12.4/en-us/>
 
@@ -401,11 +401,11 @@ part of the core and extracted at some point in time.
 
          .. rst-class:: card-header h3
 
-            .. rubric:: `System Notes <https://docs.typo3.org/c/typo3/cms-sys-note/main/en-us/>`_
+            .. rubric:: `System Notes <https://docs.typo3.org/c/typo3/cms-sys-note/12.4/en-us/>`_
 
          .. container:: card-body
 
-            The internal notes are a useful feature for adding context and notes to pages. 
+            The internal notes are a useful feature for adding context and notes to pages.
             It provides a way for users to document important information related to specific pages.
 
             `typo3/cms-sys-note <https://packagist.org/packages/typo3/cms-sys-note>`__
@@ -414,7 +414,6 @@ part of the core and extracted at some point in time.
 
             .. rst-class:: horizbuttons-striking-m
 
-            - `main <https://docs.typo3.org/c/typo3/cms-sys-note/main/en-us/>`__
             - `12.4 <https://docs.typo3.org/c/typo3/cms-sys-note/12.4/en-us/>`__
 
    .. container:: col-md-6 pl-0 pr-3 py-3 m-0


### PR DESCRIPTION
As the v12 version is now rendered successfully, we promote this version instead of main.