### PR TITLE
Update 404.rst

### DIFF
--- a/Documentation/404.rst
+++ b/Documentation/404.rst
@@ -9,7 +9,7 @@ Page not found (404)
 
 The page you were redirected to no longer exists.
 
-To search the entire TYPO3 documentation (https://docs.typo3.org), use the search
+To search the entire TYPO3 documentation (`<https://docs.typo3.org>`__), use the search
 box on the top of the page.
 
 Or pick one of the following:


### PR DESCRIPTION
On the current 404 Page I have the error that the link leads to https://docs.typo3.org)/ which is not resolvable. Hopefully this change should fix this. 