### PR TITLE
[TASK] Use --minimal-test CLI option for documentation tests

### DIFF
--- a/.github/workflows/test-documentation.yml
+++ b/.github/workflows/test-documentation.yml
@@ -14,4 +14,4 @@ jobs:
         run: |
           mkdir -p Documentation-GENERATED-temp \
           && docker run --rm --pull always -v $(pwd):/project \
-             ghcr.io/typo3-documentation/render-guides:latest --config=Documentation --no-progress --fail-on-log
+             ghcr.io/typo3-documentation/render-guides:latest --config=Documentation --no-progress --minimal-test

--- a/Makefile
+++ b/Makefile
@@ -14,5 +14,5 @@ docs: ## Generate projects docs (from "Documentation" directory)
 test-docs: ## Test the documentation rendering
 	mkdir -p Documentation-GENERATED-temp
 
-	docker run --rm --pull always -v "$(shell pwd)":/project -t ghcr.io/typo3-documentation/render-guides:latest --config=Documentation --no-progress --fail-on-log
+	docker run --rm --pull always -v "$(shell pwd)":/project -t ghcr.io/typo3-documentation/render-guides:latest --config=Documentation --no-progress --minimal-test
 


### PR DESCRIPTION
This allows us to control specific settings needed for mininmal tests (like setting only a single output format) or more for the future.

See also: https://github.com/TYPO3-Documentation/render-guides/pull/765