### PR TITLE
[TASK] TYPO3 13.4 is the new stable, 12.4 the new oldstable

### DIFF
--- a/Documentation/Home/ApiTypo3Org.rst
+++ b/Documentation/Home/ApiTypo3Org.rst
@@ -20,24 +20,16 @@ just by browsing through the various classes and methods.
 
     ..  card:: `TYPO3 13-dev API <https://api.typo3.org/main/>`__
 
-        Automatically generated API from the 
+        Automatically generated API from the
         `13-dev (main) <https://github.com/typo3/typo3>`__ branch of TYPO3.
 
-        ..  card-footer:: `API <https://api.typo3.org/main/>`__ `GitHub <https://github.com/typo3/typo3>`__ :ref:`Docs <t3coreapimain:start>`
+        ..  card-footer:: `API <https://api.typo3.org/main/>`__ `GitHub <https://github.com/typo3/typo3>`__ :ref:`Docs <t3coreapi/main:start>`
             :button-style: btn btn-light
 
     ..  card:: `TYPO3 12.4 API <https://api.typo3.org/12.4/>`__
 
-        Automatically generated API from the 
+        Automatically generated API from the
         `12.4 (current stable) <https://github.com/typo3/typo3/tree/12.4>`__ branch of TYPO3.
 
-        ..  card-footer:: `API <https://api.typo3.org/12.4/>`__ `GitHub <https://github.com/typo3/typo3/tree/12.4>`__ :ref:`Docs <t3coreapi12:start>`
-            :button-style: btn btn-light
-
-    ..  card:: `TYPO3 11.5 API <https://api.typo3.org/11.5/>`__
-
-        Automatically generated API from the 
-        `11.5 (old stable) <https://github.com/typo3/typo3/tree/11.5>`__ branch of TYPO3.
-
-        ..  card-footer:: `API <https://api.typo3.org/main/>`__ `GitHub <https://github.com/typo3/typo3/tree/11.5>`__ :ref:`Docs <t3coreapi11:start>`
+        ..  card-footer:: `API <https://api.typo3.org/12.4/>`__ `GitHub <https://github.com/typo3/typo3/tree/12.4>`__ :ref:`Docs <t3coreapi/12:start>`
             :button-style: btn btn-light

--- a/Documentation/Home/ConfiguringTYPO3.rst
+++ b/Documentation/Home/ConfiguringTYPO3.rst
@@ -48,7 +48,7 @@ Configuring TYPO3
             :button-styles: secondary
 
             :ref:`14-dev <t3coreapi/main:sitehandling>`
-            :ref:`12.4 <t3coreapi/13:sitehandling>`
+            :ref:`13.4 <t3coreapi/13:sitehandling>`
             :ref:`12.4 <t3coreapi/12:sitehandling>`
 
 
@@ -61,7 +61,7 @@ Configuring TYPO3
 
             :ref:`14-dev <t3coreapi/dev:seo>`
             :ref:`13.4 <t3coreapi/13:seo>`
-            :ref:`13.4 <t3coreapi/12:seo>`
+            :ref:`12.4 <t3coreapi/12:seo>`
 
 
     ..  card:: :ref:`Security <t3coreapi:security>`

--- a/Documentation/Home/ConfiguringTYPO3.rst
+++ b/Documentation/Home/ConfiguringTYPO3.rst
@@ -21,9 +21,9 @@ Configuring TYPO3
         ..  card-footer::
             :button-styles: secondary
 
-            :ref:`13-dev <t3coreapi/dev:configuration>`
-            :ref:`12.4 <t3coreapi:configuration>`
-            :ref:`11.5 <t3coreapi/oldstable:configuration>`
+            :ref:`14-dev <t3coreapi/main:configuration>`
+            :ref:`13.4 <t3coreapi/13:configuration>`
+            :ref:`12.4 <t3coreapi/12:configuration>`
 
 
     ..  card:: :ref:`TypoScript in 45 Minutes <t3ts45:start>`
@@ -35,9 +35,9 @@ Configuring TYPO3
             :button-styles: secondary
 
 
-            :ref:`13-dev <t3ts45/dev:start>`
-            :ref:`12.4 <t3ts45:start>`
-            :ref:`11.5 <t3ts45/oldstable:start>`
+            :ref:`14-dev <t3ts45/main:start>`
+            :ref:`13.4 <t3ts45/13:start>`
+            :ref:`12.4 <t3ts45/12:start>`
 
 
     ..  card:: :ref:`Site Handling <t3coreapi:sitehandling>`
@@ -47,9 +47,9 @@ Configuring TYPO3
         ..  card-footer::
             :button-styles: secondary
 
-            :ref:`13-dev <t3coreapi/dev:sitehandling>`
-            :ref:`12.4 <t3coreapi:sitehandling>`
-            :ref:`11.5 <t3coreapi/oldstable:sitehandling>`
+            :ref:`14-dev <t3coreapi/main:sitehandling>`
+            :ref:`12.4 <t3coreapi/13:sitehandling>`
+            :ref:`12.4 <t3coreapi/12:sitehandling>`
 
 
     ..  card:: :ref:`SEO <t3coreapi:seo>`
@@ -59,9 +59,9 @@ Configuring TYPO3
         ..  card-footer::
             :button-styles: secondary
 
-            :ref:`13-dev <t3coreapi/dev:seo>`
-            :ref:`12.4 <t3coreapi:seo>`
-            :ref:`11.5 <t3coreapi/oldstable:seo>`
+            :ref:`14-dev <t3coreapi/dev:seo>`
+            :ref:`13.4 <t3coreapi/13:seo>`
+            :ref:`13.4 <t3coreapi/12:seo>`
 
 
     ..  card:: :ref:`Security <t3coreapi:security>`
@@ -73,9 +73,9 @@ Configuring TYPO3
         ..  card-footer::
             :button-styles: secondary
 
-            :ref:`13-dev <t3coreapi/dev:security>`
-            :ref:`12.4 <t3coreapi:security>`
-            :ref:`11.5 <t3coreapi/oldstable:security>`
+            :ref:`14-dev <t3coreapi/dev:security>`
+            :ref:`13.4 <t3coreapi/13:security>`
+            :ref:`12.4 <t3coreapi/12:security>`
 
 
     ..  card:: :ref:`RTE <t3coreapi:rte>`
@@ -86,16 +86,16 @@ Configuring TYPO3
         ..  card-footer::
             :button-styles: secondary
 
-            :ref:`13-dev <t3coreapi/dev:rte>`
-            :ref:`12.4 <t3coreapi:rte>`
-            :ref:`11.5 <t3coreapi/oldstable:rte>`
+            :ref:`14-dev <t3coreapi/dev:rte>`
+            :ref:`13.4 <t3coreapi/13:rte>`
+            :ref:`12.4 <t3coreapi/12:rte>`
 
 
 ..  toctree::
     :hidden:
 
-    Configuration Overview <https://docs.typo3.org/m/typo3/reference-coreapi/12.4/en-us/Configuration/Index.html>
-    Site Handling <https://docs.typo3.org/m/typo3/reference-coreapi/12.4/en-us/ApiOverview/SiteHandling/Index.html>
-    SEO      <https://docs.typo3.org/m/typo3/reference-coreapi/12.4/en-us/ApiOverview/Seo/Index.html>
-    Security <https://docs.typo3.org/m/typo3/reference-coreapi/12.4/en-us/Security/Index.html>
-    RTE's    <https://docs.typo3.org/m/typo3/reference-coreapi/12.4/en-us/ApiOverview/Rte/Index.html>
+    Configuration Overview <https://docs.typo3.org/m/typo3/reference-coreapi/13.4/en-us/Configuration/Index.html>
+    Site Handling <https://docs.typo3.org/m/typo3/reference-coreapi/13.4/en-us/ApiOverview/SiteHandling/Index.html>
+    SEO      <https://docs.typo3.org/m/typo3/reference-coreapi/13.4/en-us/ApiOverview/Seo/Index.html>
+    Security <https://docs.typo3.org/m/typo3/reference-coreapi/13.4/en-us/Security/Index.html>
+    RTE's    <https://docs.typo3.org/m/typo3/reference-coreapi/13.4/en-us/ApiOverview/Rte/Index.html>

--- a/Documentation/Home/CreatingManagingContent.rst
+++ b/Documentation/Home/CreatingManagingContent.rst
@@ -20,9 +20,9 @@ Creating & Managing Content
         ..  card-footer::
             :button-styles: secondary
 
-            :ref:`13-dev <t3editors/dev:pages>`
-            :ref:`12.4 <t3editors:pages>`
-            :ref:`11.5 <t3editors/oldstable:pages>`
+            :ref:`14-dev <t3editors/dev:pages>`
+            :ref:`13.4 <t3editors/13:pages>`
+            :ref:`12.4 <t3editors/12:pages>`
 
     ..  card:: :ref:`Content <t3editors:content-elements>`
 
@@ -32,9 +32,9 @@ Creating & Managing Content
         ..  card-footer::
             :button-styles: secondary
 
-            :ref:`13-dev <t3editors/dev:content-elements>`
-            :ref:`12.4 <t3editors:content-elements>`
-            :ref:`11.5 <t3editors/oldstable:content-elements>`
+            :ref:`14-dev <t3editors/dev:content-elements>`
+            :ref:`13.4 <t3editors/13:content-elements>`
+            :ref:`12.4 <t3editors/12:content-elements>`
 
     ..  card:: :doc:`Localizing Pages & Content <t3translate:Index>`
 
@@ -44,9 +44,9 @@ Creating & Managing Content
         ..  card-footer::
             :button-styles: secondary
 
-            :doc:`13-dev <t3translate/dev:Index>`
-            :doc:`12.4 <t3translate:Index>`
-            :doc:`11.5 <t3translate/oldstable:Index>`
+            :doc:`14-dev <t3translate/dev:Index>`
+            :doc:`13.4 <t3translate/13:Index>`
+            :doc:`12.4 <t3translate/12:Index>`
 
     ..  card:: :doc:`Forms <typo3/cms-form:Index>`
 
@@ -56,9 +56,9 @@ Creating & Managing Content
         ..  card-footer::
             :button-styles: secondary
 
-            :doc:`13-dev <typo3/cms-form/dev:Index>`
-            :doc:`12.4 <typo3/cms-form:Index>`
-            :doc:`11.5 <typo3/cms-form/oldstable:Index>`
+            :doc:`14-dev <typo3/cms-form/dev:Index>`
+            :doc:`13.4 <typo3/cms-form/13:Index>`
+            :doc:`12.4 <typo3/cms-form/12:Index>`
 
     ..  card:: :ref:`Deep Linking <t3editors:deeplinking>`
 
@@ -68,16 +68,16 @@ Creating & Managing Content
         ..  card-footer::
             :button-styles: secondary
 
-            :ref:`13-dev <t3editors/dev:deeplinking>`
-            :ref:`12.4 <t3editors:deeplinking>`
-            :ref:`11.5 <t3editors/oldstable:deeplinking>`
+            :ref:`14-dev <t3editors/dev:deeplinking>`
+            :ref:`13.4 <t3editors/13:deeplinking>`
+            :ref:`12.4 <t3editors/12:deeplinking>`
 
 
 ..  toctree::
     :hidden:
 
-    Pages <https://docs.typo3.org/m/typo3/tutorial-editors/12.4/en-us/Pages/Index.html>
-    Content <https://docs.typo3.org/m/typo3/tutorial-editors/12.4/en-us/ContentElements/Index.html>
-    Localization<https://docs.typo3.org/m/typo3/guide-frontendlocalization/12.4/en-us/>
-    Forms <https://docs.typo3.org/c/typo3/cms-form/12.4/en-us/>
-    Deep Linking <https://docs.typo3.org/m/typo3/tutorial-editors/12.4/en-us/DeepLinking/Index.html>
+    Pages <https://docs.typo3.org/m/typo3/tutorial-editors/13.4/en-us/Pages/Index.html>
+    Content <https://docs.typo3.org/m/typo3/tutorial-editors/13.4/en-us/ContentElements/Index.html>
+    Localization<https://docs.typo3.org/m/typo3/guide-frontendlocalization/13.4/en-us/>
+    Forms <https://docs.typo3.org/c/typo3/cms-form/13.4/en-us/>
+    Deep Linking <https://docs.typo3.org/m/typo3/tutorial-editors/13.4/en-us/DeepLinking/Index.html>

--- a/Documentation/Home/GettingStarted.rst
+++ b/Documentation/Home/GettingStarted.rst
@@ -15,7 +15,7 @@ Getting Started
 
          .. rst-class:: card-header h3
 
-            .. rubric:: `Concepts <https://docs.typo3.org/m/typo3/tutorial-getting-started/12.4/en-us/Concepts/Index.html>`__
+            .. rubric:: `Concepts <https://docs.typo3.org/m/typo3/tutorial-getting-started/13.4/en-us/Concepts/Index.html>`__
 
          .. container:: card-body
 
@@ -25,9 +25,9 @@ Getting Started
 
             .. rst-class:: horizbuttons-striking-m
 
-            - `13-dev <https://docs.typo3.org/m/typo3/tutorial-getting-started/main/en-us/Concepts/Index.html>`__
+            - `14-dev <https://docs.typo3.org/m/typo3/tutorial-getting-started/main/en-us/Concepts/Index.html>`__
+            - `13.4 <https://docs.typo3.org/m/typo3/tutorial-getting-started/13.4/en-us/Concepts/Index.html>`__
             - `12.4 <https://docs.typo3.org/m/typo3/tutorial-getting-started/12.4/en-us/Concepts/Index.html>`__
-            - `11.5 <https://docs.typo3.org/m/typo3/tutorial-getting-started/11.5/en-us/Concepts/Index.html>`__
 
    .. container:: col-md-6 pl-0 pr-3 py-3 m-0
 
@@ -35,7 +35,7 @@ Getting Started
 
          .. rst-class:: card-header h3
 
-            .. rubric:: `System Requirements <https://docs.typo3.org/m/typo3/tutorial-getting-started/12.4/en-us/SystemRequirements/Index.html>`__
+            .. rubric:: `System Requirements <https://docs.typo3.org/m/typo3/tutorial-getting-started/13.4/en-us/SystemRequirements/Index.html>`__
 
          .. container:: card-body
 
@@ -45,9 +45,9 @@ Getting Started
 
             .. rst-class:: horizbuttons-striking-m
 
-            - `13-dev <https://docs.typo3.org/m/typo3/tutorial-getting-started/main/en-us/SystemRequirements/Index.html>`__
+            - `14-dev <https://docs.typo3.org/m/typo3/tutorial-getting-started/main/en-us/SystemRequirements/Index.html>`__
+            - `13.4 <https://docs.typo3.org/m/typo3/tutorial-getting-started/13.4/en-us/SystemRequirements/Index.html>`__
             - `12.4 <https://docs.typo3.org/m/typo3/tutorial-getting-started/12.4/en-us/SystemRequirements/Index.html>`__
-            - `11.5 <https://docs.typo3.org/m/typo3/tutorial-getting-started/11.5/en-us/SystemRequirements/Index.html>`__
 
    .. container:: col-md-6 pl-0 pr-3 py-3 m-0
 
@@ -55,7 +55,7 @@ Getting Started
 
          .. rst-class:: card-header h3
 
-            .. rubric:: `Installation <https://docs.typo3.org/m/typo3/tutorial-getting-started/12.4/en-us/Installation/Index.html>`__
+            .. rubric:: `Installation <https://docs.typo3.org/m/typo3/tutorial-getting-started/13.4/en-us/Installation/Index.html>`__
 
          .. container:: card-body
 
@@ -65,9 +65,9 @@ Getting Started
 
             .. rst-class:: horizbuttons-striking-m
 
-            - `13-dev <https://docs.typo3.org/m/typo3/tutorial-getting-started/main/en-us/Installation/Index.html>`__
+            - `14-dev <https://docs.typo3.org/m/typo3/tutorial-getting-started/main/en-us/Installation/Index.html>`__
+            - `13.4 <https://docs.typo3.org/m/typo3/tutorial-getting-started/13.4/en-us/Installation/Index.html>`__
             - `12.4 <https://docs.typo3.org/m/typo3/tutorial-getting-started/12.4/en-us/Installation/Index.html>`__
-            - `11.5 <https://docs.typo3.org/m/typo3/tutorial-getting-started/11.5/en-us/Installation/Index.html>`__
 
    .. container:: col-md-6 pl-0 pr-3 py-3 m-0
 
@@ -75,7 +75,7 @@ Getting Started
 
          .. rst-class:: card-header h3
 
-            .. rubric:: `Setup <https://docs.typo3.org/m/typo3/tutorial-getting-started/12.4/en-us/Setup/Index.html>`__
+            .. rubric:: `Setup <https://docs.typo3.org/m/typo3/tutorial-getting-started/13.4/en-us/Setup/Index.html>`__
 
          .. container:: card-body
 
@@ -85,9 +85,9 @@ Getting Started
 
             .. rst-class:: horizbuttons-striking-m
 
-            - `13-dev <https://docs.typo3.org/m/typo3/tutorial-getting-started/main/en-us/Setup/Index.html>`__
+            - `14-dev <https://docs.typo3.org/m/typo3/tutorial-getting-started/main/en-us/Setup/Index.html>`__
+            - `13.4 <https://docs.typo3.org/m/typo3/tutorial-getting-started/13.4/en-us/Setup/Index.html>`__
             - `12.4 <https://docs.typo3.org/m/typo3/tutorial-getting-started/12.4/en-us/Setup/Index.html>`__
-            - `11.5 <https://docs.typo3.org/m/typo3/tutorial-getting-started/11.5/en-us/Setup/Index.html>`__
 
    .. container:: col-md-6 pl-0 pr-3 py-3 m-0
 
@@ -95,7 +95,7 @@ Getting Started
 
          .. rst-class:: card-header h3
 
-            .. rubric:: `Troubleshooting <https://docs.typo3.org/m/typo3/tutorial-getting-started/12.4/en-us/Troubleshooting/Index.html>`__
+            .. rubric:: `Troubleshooting <https://docs.typo3.org/m/typo3/tutorial-getting-started/13.4/en-us/Troubleshooting/Index.html>`__
 
          .. container:: card-body
 
@@ -105,9 +105,9 @@ Getting Started
 
             .. rst-class:: horizbuttons-striking-m
 
-            - `13-dev <https://docs.typo3.org/m/typo3/tutorial-getting-started/main/en-us/Troubleshooting/Index.html>`__
+            - `14-dev <https://docs.typo3.org/m/typo3/tutorial-getting-started/main/en-us/Troubleshooting/Index.html>`__
+            - `13.4 <https://docs.typo3.org/m/typo3/tutorial-getting-started/13.4/en-us/Troubleshooting/Index.html>`__
             - `12.4 <https://docs.typo3.org/m/typo3/tutorial-getting-started/12.4/en-us/Troubleshooting/Index.html>`__
-            - `11.5 <https://docs.typo3.org/m/typo3/tutorial-getting-started/11.5/en-us/Troubleshooting/Index.html>`__
 
    .. container:: col-md-6 pl-0 pr-3 py-3 m-0
 
@@ -115,7 +115,7 @@ Getting Started
 
          .. rst-class:: card-header h3
 
-            .. rubric:: `Managing Backend Users <https://docs.typo3.org/m/typo3/tutorial-getting-started/12.4/en-us/UserManagement/Index.html>`__
+            .. rubric:: `Managing Backend Users <https://docs.typo3.org/m/typo3/tutorial-getting-started/13.4/en-us/UserManagement/Index.html>`__
 
          .. container:: card-body
 
@@ -125,9 +125,9 @@ Getting Started
 
             .. rst-class:: horizbuttons-striking-m
 
-            - `13-dev <https://docs.typo3.org/m/typo3/tutorial-getting-started/main/en-us/UserManagement/Index.html>`__
+            - `14-dev <https://docs.typo3.org/m/typo3/tutorial-getting-started/main/en-us/UserManagement/Index.html>`__
+            - `13.4 <https://docs.typo3.org/m/typo3/tutorial-getting-started/13.4/en-us/UserManagement/Index.html>`__
             - `12.4 <https://docs.typo3.org/m/typo3/tutorial-getting-started/12.4/en-us/UserManagement/Index.html>`__
-            - `11.5 <https://docs.typo3.org/m/typo3/tutorial-getting-started/11.5/en-us/UserManagement/Index.html>`__
 
    .. container:: col-md-6 pl-0 pr-3 py-3 m-0
 
@@ -135,7 +135,7 @@ Getting Started
 
          .. rst-class:: card-header h3
 
-            .. rubric:: `Working With Extensions <https://docs.typo3.org/m/typo3/tutorial-getting-started/12.4/en-us/Extensions/Index.html>`__
+            .. rubric:: `Working With Extensions <https://docs.typo3.org/m/typo3/tutorial-getting-started/13.4/en-us/Extensions/Index.html>`__
 
          .. container:: card-body
 
@@ -145,9 +145,9 @@ Getting Started
 
             .. rst-class:: horizbuttons-striking-m
 
-            - `13-dev <https://docs.typo3.org/m/typo3/tutorial-getting-started/main/en-us/Extensions/Index.html>`__
+            - `14-dev <https://docs.typo3.org/m/typo3/tutorial-getting-started/main/en-us/Extensions/Index.html>`__
+            - `13.4 <https://docs.typo3.org/m/typo3/tutorial-getting-started/13.4/en-us/Extensions/Index.html>`__
             - `12.4 <https://docs.typo3.org/m/typo3/tutorial-getting-started/12.4/en-us/Extensions/Index.html>`__
-            - `11.5 <https://docs.typo3.org/m/typo3/tutorial-getting-started/11.5/en-us/Extensions/Index.html>`__
 
    .. container:: col-md-6 pl-0 pr-3 py-3 m-0
 
@@ -155,7 +155,7 @@ Getting Started
 
          .. rst-class:: card-header h3
 
-            .. rubric:: `The Introduction Package <https://docs.typo3.org/m/typo3/tutorial-getting-started/12.4/en-us/IntroductionPackage/Index.html>`__
+            .. rubric:: `The Introduction Package <https://docs.typo3.org/m/typo3/tutorial-getting-started/13.4/en-us/IntroductionPackage/Index.html>`__
 
          .. container:: card-body
 
@@ -166,9 +166,9 @@ Getting Started
 
             .. rst-class:: horizbuttons-striking-m
 
-            - `13-dev <https://docs.typo3.org/m/typo3/tutorial-getting-started/main/en-us/IntroductionPackage/Index.html>`__
+            - `14-dev <https://docs.typo3.org/m/typo3/tutorial-getting-started/main/en-us/IntroductionPackage/Index.html>`__
+            - `13.4 <https://docs.typo3.org/m/typo3/tutorial-getting-started/13.4/en-us/IntroductionPackage/Index.html>`__
             - `12.4 <https://docs.typo3.org/m/typo3/tutorial-getting-started/12.4/en-us/IntroductionPackage/Index.html>`__
-            - `11.5 <https://docs.typo3.org/m/typo3/tutorial-getting-started/11.5/en-us/IntroductionPackage/Index.html>`__
 
    .. container:: col-md-6 pl-0 pr-3 py-3 m-0
 
@@ -176,7 +176,7 @@ Getting Started
 
          .. rst-class:: card-header h3
 
-            .. rubric:: `Next Steps <https://docs.typo3.org/m/typo3/tutorial-getting-started/12.4/en-us/NextSteps/Index.html>`__
+            .. rubric:: `Next Steps <https://docs.typo3.org/m/typo3/tutorial-getting-started/13.4/en-us/NextSteps/Index.html>`__
 
          .. container:: card-body
 
@@ -186,20 +186,20 @@ Getting Started
 
             .. rst-class:: horizbuttons-striking-m
 
-            - `13-dev <https://docs.typo3.org/m/typo3/tutorial-getting-started/main/en-us/NextSteps/Index.html>`__
+            - `14-dev <https://docs.typo3.org/m/typo3/tutorial-getting-started/main/en-us/NextSteps/Index.html>`__
+            - `13.4 <https://docs.typo3.org/m/typo3/tutorial-getting-started/13.4/en-us/NextSteps/Index.html>`__
             - `12.4 <https://docs.typo3.org/m/typo3/tutorial-getting-started/12.4/en-us/NextSteps/Index.html>`__
-            - `11.5 <https://docs.typo3.org/m/typo3/tutorial-getting-started/11.5/en-us/NextSteps/Index.html>`__
 
 
    .. toctree::
       :hidden:
 
-      TYPO3 Concepts          <https://docs.typo3.org/m/typo3/tutorial-getting-started/12.4/en-us/Concepts/Index.html#concepts>
-      System Requirements     <https://docs.typo3.org/m/typo3/tutorial-getting-started/12.4/en-us/SystemRequirements/Index.html#system-requirements>
-      Installation            <https://docs.typo3.org/m/typo3/tutorial-getting-started/12.4/en-us/Installation/Index.html>
-      Setup                   <https://docs.typo3.org/m/typo3/tutorial-getting-started/12.4/en-us/Setup/Index.html>
-      Troubleshooting         <https://docs.typo3.org/m/typo3/tutorial-getting-started/12.4/en-us/Troubleshooting/Index.html>
-      Managing Backend Users  <https://docs.typo3.org/m/typo3/tutorial-getting-started/12.4/en-us/UserManagement/Index.html>
-      Working With Extensions <https://docs.typo3.org/m/typo3/tutorial-getting-started/12.4/en-us/Extensions/Index.html>
-      Introduction Package    <https://docs.typo3.org/m/typo3/tutorial-getting-started/12.4/en-us/IntroductionPackage/Index.html>
-      Next Steps              <https://docs.typo3.org/m/typo3/tutorial-getting-started/12.4/en-us/NextSteps/Index.html>
+      TYPO3 Concepts          <https://docs.typo3.org/m/typo3/tutorial-getting-started/13.4/en-us/Concepts/Index.html#concepts>
+      System Requirements     <https://docs.typo3.org/m/typo3/tutorial-getting-started/13.4/en-us/SystemRequirements/Index.html#system-requirements>
+      Installation            <https://docs.typo3.org/m/typo3/tutorial-getting-started/13.4/en-us/Installation/Index.html>
+      Setup                   <https://docs.typo3.org/m/typo3/tutorial-getting-started/13.4/en-us/Setup/Index.html>
+      Troubleshooting         <https://docs.typo3.org/m/typo3/tutorial-getting-started/13.4/en-us/Troubleshooting/Index.html>
+      Managing Backend Users  <https://docs.typo3.org/m/typo3/tutorial-getting-started/13.4/en-us/UserManagement/Index.html>
+      Working With Extensions <https://docs.typo3.org/m/typo3/tutorial-getting-started/13.4/en-us/Extensions/Index.html>
+      Introduction Package    <https://docs.typo3.org/m/typo3/tutorial-getting-started/13.4/en-us/IntroductionPackage/Index.html>
+      Next Steps              <https://docs.typo3.org/m/typo3/tutorial-getting-started/13.4/en-us/NextSteps/Index.html>

--- a/Documentation/Home/References.rst
+++ b/Documentation/Home/References.rst
@@ -33,7 +33,7 @@ Reference Manuals
         ..  card-footer::
             :button-styles: secondary
 
-            :doc:`14-dev <changelog:Changelog-13>`
+            :doc:`13-dev <changelog:Changelog-13>`
             :doc:`v12 <changelog:Changelog-12>`
             :doc:`v11 <changelog/oldstable:Changelog-11>`
 

--- a/Documentation/Home/References.rst
+++ b/Documentation/Home/References.rst
@@ -21,9 +21,9 @@ Reference Manuals
         ..  card-footer::
             :button-styles: secondary
 
-            :ref:`13-dev <t3coreapi/dev:start>`
-            :ref:`12.4 <t3coreapi:start>`
-            :ref:`11.5 <t3coreapi/oldstable:start>`
+            :ref:`14-dev <t3coreapi/dev:start>`
+            :ref:`13.4 <t3coreapi:start>`
+            :ref:`12.4 <t3coreapi/oldstable:start>`
 
 
     ..  card:: :doc:`Changelog <changelog:Index>`
@@ -33,7 +33,7 @@ Reference Manuals
         ..  card-footer::
             :button-styles: secondary
 
-            :doc:`13-dev <changelog:Changelog-13>`
+            :doc:`14-dev <changelog:Changelog-13>`
             :doc:`v12 <changelog:Changelog-12>`
             :doc:`v11 <changelog/oldstable:Changelog-11>`
 
@@ -46,9 +46,9 @@ Reference Manuals
         ..  card-footer::
             :button-styles: secondary
 
-            :ref:`13-dev <t3tca/dev:start>`
-            :ref:`12.4 <t3tca:start>`
-            :ref:`11.5 <t3tca/oldstable:start>`
+            :ref:`14-dev <t3tca/dev:start>`
+            :ref:`13.4 <t3tca:start>`
+            :ref:`12.4 <t3tca/oldstable:start>`
 
 
     ..  card:: :ref:`t3tsconfig:start`
@@ -59,9 +59,9 @@ Reference Manuals
         ..  card-footer::
             :button-styles: secondary
 
-            :ref:`13-dev <t3tsconfig/dev:start>`
-            :ref:`12.4 <t3tsconfig:start>`
-            :ref:`11.5 <t3tsconfig/oldstable:start>`
+            :ref:`14-dev <t3tsconfig/dev:start>`
+            :ref:`13.4 <t3tsconfig:start>`
+            :ref:`12.4 <t3tsconfig/oldstable:start>`
 
 
     ..  card:: :ref:`t3tsref:start`
@@ -72,9 +72,9 @@ Reference Manuals
         ..  card-footer::
             :button-styles: secondary
 
-            :ref:`13-dev <t3tsref/dev:start>`
-            :ref:`12.4 <t3tsref:start>`
-            :ref:`11.5 <t3tsref/oldstable:start>`
+            :ref:`14-dev <t3tsref/dev:start>`
+            :ref:`13.4 <t3tsref:start>`
+            :ref:`12.4 <t3tsref/oldstable:start>`
 
     ..  card:: :ref:`t3viewhelper:start`
 
@@ -84,9 +84,9 @@ Reference Manuals
         ..  card-footer::
             :button-styles: secondary
 
-            :ref:`13-dev <t3viewhelper/dev:start>`
-            :ref:`12.4 <t3viewhelper:start>`
-            :ref:`11.5 <t3viewhelper/oldstable:start>`
+            :ref:`14-dev <t3viewhelper/dev:start>`
+            :ref:`13.4 <t3viewhelper:start>`
+            :ref:`12.4 <t3viewhelper/oldstable:start>`
 
 
 ..  tip::
@@ -99,9 +99,9 @@ Reference Manuals
 ..  toctree::
     :hidden:
 
-    TYPO3 Explained   <https://docs.typo3.org/m/typo3/reference-coreapi/12.4/en-us/>
+    TYPO3 Explained   <https://docs.typo3.org/m/typo3/reference-coreapi/13.4/en-us/>
     Changelog         <https://docs.typo3.org/c/typo3/cms-core/main/en-us/>
-    TCA               <https://docs.typo3.org/m/typo3/reference-tca/12.4/en-us/>
-    TSconfig          <https://docs.typo3.org/m/typo3/reference-tsconfig/12.4/en-us/>
-    TypoScript        <https://docs.typo3.org/m/typo3/reference-typoscript/12.4/en-us/>
-    Fluid ViewHelpers <https://docs.typo3.org/other/typo3/view-helper-reference/12.4/en-us/>
+    TCA               <https://docs.typo3.org/m/typo3/reference-tca/13.4/en-us/>
+    TSconfig          <https://docs.typo3.org/m/typo3/reference-tsconfig/13.4/en-us/>
+    TypoScript        <https://docs.typo3.org/m/typo3/reference-typoscript/13.4/en-us/>
+    Fluid ViewHelpers <https://docs.typo3.org/other/typo3/view-helper-reference/13.4/en-us/>

--- a/Documentation/Home/References.rst
+++ b/Documentation/Home/References.rst
@@ -47,8 +47,8 @@ Reference Manuals
             :button-styles: secondary
 
             :ref:`14-dev <t3tca/dev:start>`
-            :ref:`13.4 <t3tca:start>`
-            :ref:`12.4 <t3tca/oldstable:start>`
+            :ref:`13.4 <t3tca/13:start>`
+            :ref:`12.4 <t3tca/12:start>`
 
 
     ..  card:: :ref:`t3tsconfig:start`
@@ -60,8 +60,8 @@ Reference Manuals
             :button-styles: secondary
 
             :ref:`14-dev <t3tsconfig/dev:start>`
-            :ref:`13.4 <t3tsconfig:start>`
-            :ref:`12.4 <t3tsconfig/oldstable:start>`
+            :ref:`13.4 <t3tsconfig/13:start>`
+            :ref:`12.4 <t3tsconfig/12:start>`
 
 
     ..  card:: :ref:`t3tsref:start`
@@ -73,8 +73,8 @@ Reference Manuals
             :button-styles: secondary
 
             :ref:`14-dev <t3tsref/dev:start>`
-            :ref:`13.4 <t3tsref:start>`
-            :ref:`12.4 <t3tsref/oldstable:start>`
+            :ref:`13.4 <t3tsref/13:start>`
+            :ref:`12.4 <t3tsref/12:start>`
 
     ..  card:: :ref:`t3viewhelper:start`
 
@@ -85,8 +85,8 @@ Reference Manuals
             :button-styles: secondary
 
             :ref:`14-dev <t3viewhelper/dev:start>`
-            :ref:`13.4 <t3viewhelper:start>`
-            :ref:`12.4 <t3viewhelper/oldstable:start>`
+            :ref:`13.4 <t3viewhelper/13:start>`
+            :ref:`12.4 <t3viewhelper/12:start>`
 
 
 ..  tip::

--- a/Documentation/Home/References.rst
+++ b/Documentation/Home/References.rst
@@ -22,8 +22,8 @@ Reference Manuals
             :button-styles: secondary
 
             :ref:`14-dev <t3coreapi/dev:start>`
-            :ref:`13.4 <t3coreapi:start>`
-            :ref:`12.4 <t3coreapi/oldstable:start>`
+            :ref:`13.4 <t3coreapi/13:start>`
+            :ref:`12.4 <t3coreapi/12:start>`
 
 
     ..  card:: :doc:`Changelog <changelog:Index>`

--- a/Documentation/Home/SystemExtensions.rst
+++ b/Documentation/Home/SystemExtensions.rst
@@ -282,7 +282,7 @@ part of the Core and extracted at some point in time.
             :button-styles: secondary
 
             :doc:`14-dev <typo3/cms-sys-note/dev:Index>`
-            :doc:`13.4 <typo3/cms-sys-note:Index>`
+            :doc:`13.4 <typo3/cms-sys-note/13:Index>`
 
     ..  card:: :doc:`T3Editor <typo3/cms-t3editor:Index>`
 

--- a/Documentation/Home/SystemExtensions.rst
+++ b/Documentation/Home/SystemExtensions.rst
@@ -21,25 +21,25 @@ own documentation; the functionality is documented in
 ..  toctree::
     :hidden:
 
-    adminpanel           <https://docs.typo3.org/c/typo3/cms-adminpanel/12.4/en-us/>
-    dashboard            <https://docs.typo3.org/c/typo3/cms-dashboard/12.4/en-us/>
-    felogin              <https://docs.typo3.org/c/typo3/cms-felogin/12.4/en-us/>
-    fluid_styled_content <https://docs.typo3.org/c/typo3/cms-fluid-styled-content/12.4/en-us/>
-    form                 <https://docs.typo3.org/c/typo3/cms-form/12.4/en-us/>
-    impexp               <https://docs.typo3.org/c/typo3/cms-impexp/12.4/en-us/>
-    indexed_search       <https://docs.typo3.org/c/typo3/cms-indexed-search/12.4/en-us/>
-    linkvalidator        <https://docs.typo3.org/c/typo3/cms-linkvalidator/12.4/en-us/>
-    lowlevel             <https://docs.typo3.org/c/typo3/cms-lowlevel/12.4/en-us/>
-    reactions            <https://docs.typo3.org/c/typo3/cms-reactions/12.4/en-us/>
-    recycler             <https://docs.typo3.org/c/typo3/cms-recycler/12.4/en-us/>
-    redirects            <https://docs.typo3.org/c/typo3/cms-redirects/12.4/en-us/>
-    reports              <https://docs.typo3.org/c/typo3/cms-reports/12.4/en-us/>
-    rte_ckeditor         <https://docs.typo3.org/c/typo3/cms-rte-ckeditor/12.4/en-us/>
-    scheduler            <https://docs.typo3.org/c/typo3/cms-scheduler/12.4/en-us/>
-    seo                  <https://docs.typo3.org/c/typo3/cms-seo/12.4/en-us/>
-    sys_note             <https://docs.typo3.org/c/typo3/cms-sys-note/12.4/en-us/>
-    t3editor             <https://docs.typo3.org/c/typo3/cms-t3editor/12.4/en-us/>
-    workspaces           <https://docs.typo3.org/c/typo3/cms-workspaces/12.4/en-us/>
+    adminpanel           <https://docs.typo3.org/c/typo3/cms-adminpanel/13.4/en-us/>
+    dashboard            <https://docs.typo3.org/c/typo3/cms-dashboard/13.4/en-us/>
+    felogin              <https://docs.typo3.org/c/typo3/cms-felogin/13.4/en-us/>
+    fluid_styled_content <https://docs.typo3.org/c/typo3/cms-fluid-styled-content/13.4/en-us/>
+    form                 <https://docs.typo3.org/c/typo3/cms-form/13.4/en-us/>
+    impexp               <https://docs.typo3.org/c/typo3/cms-impexp/13.4/en-us/>
+    indexed_search       <https://docs.typo3.org/c/typo3/cms-indexed-search/13.4/en-us/>
+    linkvalidator        <https://docs.typo3.org/c/typo3/cms-linkvalidator/13.4/en-us/>
+    lowlevel             <https://docs.typo3.org/c/typo3/cms-lowlevel/13.4/en-us/>
+    reactions            <https://docs.typo3.org/c/typo3/cms-reactions/13.4/en-us/>
+    recycler             <https://docs.typo3.org/c/typo3/cms-recycler/13.4/en-us/>
+    redirects            <https://docs.typo3.org/c/typo3/cms-redirects/13.4/en-us/>
+    reports              <https://docs.typo3.org/c/typo3/cms-reports/13.4/en-us/>
+    rte_ckeditor         <https://docs.typo3.org/c/typo3/cms-rte-ckeditor/13.4/en-us/>
+    scheduler            <https://docs.typo3.org/c/typo3/cms-scheduler/13.4/en-us/>
+    seo                  <https://docs.typo3.org/c/typo3/cms-seo/13.4/en-us/>
+    sys_note             <https://docs.typo3.org/c/typo3/cms-sys-note/13.4/en-us/>
+    t3editor             <https://docs.typo3.org/c/typo3/cms-t3editor/13.4/en-us/>
+    workspaces           <https://docs.typo3.org/c/typo3/cms-workspaces/13.4/en-us/>
 
 Documentation of system extensions in current Core version
 ==========================================================
@@ -69,9 +69,9 @@ part of the Core and extracted at some point in time.
         ..  card-footer::
             :button-styles: secondary
 
-            :doc:`13-dev <typo3/cms-adminpanel/dev:Index>`
-            :doc:`12.4 <typo3/cms-adminpanel:Index>`
-            :doc:`11.5 <typo3/cms-adminpanel/oldstable:Index>`
+            :doc:`14-dev <typo3/cms-adminpanel/dev:Index>`
+            :doc:`13.4 <typo3/cms-adminpanel:Index>`
+            :doc:`12.4 <typo3/cms-adminpanel/oldstable:Index>`
 
     ..  card:: :doc:`Dashboard <typo3/cms-dashboard:Index>`
 
@@ -82,9 +82,9 @@ part of the Core and extracted at some point in time.
         ..  card-footer::
             :button-styles: secondary
 
-            :doc:`13-dev <typo3/cms-dashboard/dev:Index>`
-            :doc:`12.4 <typo3/cms-dashboard:Index>`
-            :doc:`11.5 <typo3/cms-dashboard/oldstable:Index>`
+            :doc:`14-dev <typo3/cms-dashboard/dev:Index>`
+            :doc:`13.4 <typo3/cms-dashboard:Index>`
+            :doc:`12.4 <typo3/cms-dashboard/oldstable:Index>`
 
     ..  card:: :doc:`Frontend Login <typo3/cms-felogin:Index>`
 
@@ -95,9 +95,9 @@ part of the Core and extracted at some point in time.
         ..  card-footer::
             :button-styles: secondary
 
-            :doc:`13-dev <typo3/cms-felogin/dev:Index>`
-            :doc:`12.4 <typo3/cms-felogin:Index>`
-            :doc:`11.5 <typo3/cms-felogin/oldstable:Index>`
+            :doc:`14-dev <typo3/cms-felogin/dev:Index>`
+            :doc:`13.4 <typo3/cms-felogin:Index>`
+            :doc:`12.4 <typo3/cms-felogin/oldstable:Index>`
 
 
     ..  card:: :doc:`Fluid Styled Content <typo3/cms-fluid-styled-content:Index>`
@@ -109,9 +109,9 @@ part of the Core and extracted at some point in time.
         ..  card-footer::
             :button-styles: secondary
 
-            :doc:`13-dev <typo3/cms-fluid-styled-content/dev:Index>`
-            :doc:`12.4 <typo3/cms-fluid-styled-content:Index>`
-            :doc:`11.5 <typo3/cms-fluid-styled-content/oldstable:Index>`
+            :doc:`14-dev <typo3/cms-fluid-styled-content/dev:Index>`
+            :doc:`13.4 <typo3/cms-fluid-styled-content:Index>`
+            :doc:`12.4 <typo3/cms-fluid-styled-content/oldstable:Index>`
 
     ..  card:: :doc:`Form framework <typo3/cms-form:Index>`
 
@@ -122,9 +122,9 @@ part of the Core and extracted at some point in time.
         ..  card-footer::
             :button-styles: secondary
 
-            :doc:`13-dev <typo3/cms-form/dev:Index>`
-            :doc:`12.4 <typo3/cms-form:Index>`
-            :doc:`11.5 <typo3/cms-form/oldstable:Index>`
+            :doc:`14-dev <typo3/cms-form/dev:Index>`
+            :doc:`13.4 <typo3/cms-form:Index>`
+            :doc:`12.4 <typo3/cms-form/oldstable:Index>`
 
     ..  card:: :doc:`Indexed Search <typo3/cms-indexed-search:Index>`
 
@@ -136,9 +136,9 @@ part of the Core and extracted at some point in time.
         ..  card-footer::
             :button-styles: secondary
 
-            :doc:`13-dev <typo3/cms-indexed-search/dev:Index>`
-            :doc:`12.4 <typo3/cms-indexed-search:Index>`
-            :doc:`11.5 <typo3/cms-indexed-search/oldstable:Index>`
+            :doc:`14-dev <typo3/cms-indexed-search/dev:Index>`
+            :doc:`13.4 <typo3/cms-indexed-search:Index>`
+            :doc:`12.4 <typo3/cms-indexed-search/oldstable:Index>`
 
     ..  card:: :doc:`Import / Export <typo3/cms-impexp:Index>`
 
@@ -150,9 +150,9 @@ part of the Core and extracted at some point in time.
         ..  card-footer::
             :button-styles: secondary
 
-            :doc:`13-dev <typo3/cms-impexp/dev:Index>`
-            :doc:`12.4 <typo3/cms-impexp:Index>`
-            :doc:`11.5 <typo3/cms-impexp/oldstable:Index>`
+            :doc:`14-dev <typo3/cms-impexp/dev:Index>`
+            :doc:`13.4 <typo3/cms-impexp:Index>`
+            :doc:`12.4 <typo3/cms-impexp/oldstable:Index>`
 
     ..  card:: :doc:`Link Validator <typo3/cms-linkvalidator:Index>`
 
@@ -163,9 +163,9 @@ part of the Core and extracted at some point in time.
         ..  card-footer::
             :button-styles: secondary
 
-            :doc:`13-dev <typo3/cms-linkvalidator/dev:Index>`
-            :doc:`12.4 <typo3/cms-linkvalidator:Index>`
-            :doc:`11.5 <typo3/cms-linkvalidator/oldstable:Index>`
+            :doc:`14-dev <typo3/cms-linkvalidator/dev:Index>`
+            :doc:`13.4 <typo3/cms-linkvalidator:Index>`
+            :doc:`12.4 <typo3/cms-linkvalidator/oldstable:Index>`
 
     ..  card:: :doc:`Lowlevel <typo3/cms-lowlevel:Index>`
 
@@ -177,9 +177,9 @@ part of the Core and extracted at some point in time.
         ..  card-footer::
             :button-styles: secondary
 
-            :doc:`13-dev <typo3/cms-lowlevel/dev:Index>`
-            :doc:`12.4 <typo3/cms-lowlevel:Index>`
-            :doc:`11.5 <typo3/cms-lowlevel/oldstable:Index>`
+            :doc:`14-dev <typo3/cms-lowlevel/dev:Index>`
+            :doc:`13.4 <typo3/cms-lowlevel:Index>`
+            :doc:`12.4 <typo3/cms-lowlevel/oldstable:Index>`
 
     ..  card:: :doc:`Reactions <typo3/cms-reactions:Index>`
 
@@ -190,8 +190,8 @@ part of the Core and extracted at some point in time.
         ..  card-footer::
             :button-styles: secondary
 
-            :doc:`13-dev <typo3/cms-reactions/dev:Index>`
-            :doc:`12.4 <typo3/cms-reactions:Index>`
+            :doc:`14-dev <typo3/cms-reactions/dev:Index>`
+            :doc:`13.4 <typo3/cms-reactions:Index>`
 
     ..  card:: :doc:`Recycler <typo3/cms-recycler:Index>`
 
@@ -202,9 +202,9 @@ part of the Core and extracted at some point in time.
         ..  card-footer::
             :button-styles: secondary
 
-            :doc:`13-dev <typo3/cms-recycler/dev:Index>`
-            :doc:`12.4 <typo3/cms-recycler:Index>`
-            :doc:`11.5 <typo3/cms-recycler/oldstable:Index>`
+            :doc:`14-dev <typo3/cms-recycler/dev:Index>`
+            :doc:`13.4 <typo3/cms-recycler:Index>`
+            :doc:`12.4 <typo3/cms-recycler/oldstable:Index>`
 
     ..  card:: :doc:`Redirects <typo3/cms-redirects:Index>`
 
@@ -215,9 +215,9 @@ part of the Core and extracted at some point in time.
         ..  card-footer::
             :button-styles: secondary
 
-            :doc:`13-dev <typo3/cms-redirects/dev:Index>`
-            :doc:`12.4 <typo3/cms-redirects:Index>`
-            :doc:`11.5 <typo3/cms-redirects/oldstable:Index>`
+            :doc:`14-dev <typo3/cms-redirects/dev:Index>`
+            :doc:`13.4 <typo3/cms-redirects:Index>`
+            :doc:`12.4 <typo3/cms-redirects/oldstable:Index>`
 
     ..  card:: :doc:`Reports <typo3/cms-reports:Index>`
 
@@ -229,8 +229,8 @@ part of the Core and extracted at some point in time.
         ..  card-footer::
             :button-styles: secondary
 
-            :doc:`13-dev <typo3/cms-reports/dev:Index>`
-            :doc:`12.4 <typo3/cms-reports:Index>`
+            :doc:`14-dev <typo3/cms-reports/dev:Index>`
+            :doc:`13.4 <typo3/cms-reports:Index>`
 
     ..  card:: :doc:`CKEditor <typo3/cms-rte-ckeditor:Index>`
 
@@ -241,9 +241,9 @@ part of the Core and extracted at some point in time.
         ..  card-footer::
             :button-styles: secondary
 
-            :doc:`13-dev <typo3/cms-rte-ckeditor/dev:Index>`
-            :doc:`12.4 <typo3/cms-rte-ckeditor:Index>`
-            :doc:`11.5 <typo3/cms-rte-ckeditor/oldstable:Index>`
+            :doc:`14-dev <typo3/cms-rte-ckeditor/dev:Index>`
+            :doc:`13.4 <typo3/cms-rte-ckeditor:Index>`
+            :doc:`12.4 <typo3/cms-rte-ckeditor/oldstable:Index>`
 
     ..  card:: :doc:`Scheduler <typo3/cms-scheduler:Index>`
 
@@ -254,9 +254,9 @@ part of the Core and extracted at some point in time.
         ..  card-footer::
             :button-styles: secondary
 
-            :doc:`13-dev <typo3/cms-scheduler/dev:Index>`
-            :doc:`12.4 <typo3/cms-scheduler:Index>`
-            :doc:`11.5 <typo3/cms-scheduler/oldstable:Index>`
+            :doc:`14-dev <typo3/cms-scheduler/dev:Index>`
+            :doc:`13.4 <typo3/cms-scheduler:Index>`
+            :doc:`12.4 <typo3/cms-scheduler/oldstable:Index>`
 
     ..  card:: :doc:`SEO <typo3/cms-seo:Index>`
 
@@ -267,9 +267,9 @@ part of the Core and extracted at some point in time.
         ..  card-footer::
             :button-styles: secondary
 
-            :doc:`13-dev <typo3/cms-seo/dev:Index>`
-            :doc:`12.4 <typo3/cms-seo:Index>`
-            :doc:`11.5 <typo3/cms-seo/oldstable:Index>`
+            :doc:`14-dev <typo3/cms-seo/dev:Index>`
+            :doc:`13.4 <typo3/cms-seo:Index>`
+            :doc:`12.4 <typo3/cms-seo/oldstable:Index>`
 
     ..  card:: :doc:`System Notes <typo3/cms-sys-note:Index>`
 
@@ -281,8 +281,8 @@ part of the Core and extracted at some point in time.
         ..  card-footer::
             :button-styles: secondary
 
-            :doc:`13-dev <typo3/cms-sys-note/dev:Index>`
-            :doc:`12.4 <typo3/cms-sys-note:Index>`
+            :doc:`14-dev <typo3/cms-sys-note/dev:Index>`
+            :doc:`13.4 <typo3/cms-sys-note:Index>`
 
     ..  card:: :doc:`T3Editor <typo3/cms-t3editor:Index>`
 
@@ -295,9 +295,9 @@ part of the Core and extracted at some point in time.
         ..  card-footer::
             :button-styles: secondary
 
-            :doc:`13-dev <typo3/cms-t3editor/dev:Index>`
-            :doc:`12.4 <typo3/cms-t3editor:Index>`
-            :doc:`11.5 <typo3/cms-t3editor/oldstable:Index>`
+            :doc:`14-dev <typo3/cms-t3editor/dev:Index>`
+            :doc:`13.4 <typo3/cms-t3editor:Index>`
+            :doc:`12.4 <typo3/cms-t3editor/oldstable:Index>`
 
     ..  card:: :doc:`Workspaces and Versioning <typo3/cms-workspaces:Index>`
 
@@ -308,9 +308,9 @@ part of the Core and extracted at some point in time.
         ..  card-footer::
             :button-styles: secondary
 
-            :doc:`13-dev <typo3/cms-workspaces/dev:Index>`
-            :doc:`12.4 <typo3/cms-workspaces:Index>`
-            :doc:`11.5 <typo3/cms-workspaces/oldstable:Index>`
+            :doc:`14-dev <typo3/cms-workspaces/dev:Index>`
+            :doc:`13.4 <typo3/cms-workspaces:Index>`
+            :doc:`12.4 <typo3/cms-workspaces/oldstable:Index>`
 
 .. _System-Extensions-outdated:
 

--- a/Documentation/Home/SystemExtensions.rst
+++ b/Documentation/Home/SystemExtensions.rst
@@ -70,8 +70,8 @@ part of the Core and extracted at some point in time.
             :button-styles: secondary
 
             :doc:`14-dev <typo3/cms-adminpanel/dev:Index>`
-            :doc:`13.4 <typo3/cms-adminpanel:Index>`
-            :doc:`12.4 <typo3/cms-adminpanel/oldstable:Index>`
+            :doc:`13.4 <typo3/cms-adminpanel/13:Index>`
+            :doc:`12.4 <typo3/cms-adminpanel/12:Index>`
 
     ..  card:: :doc:`Dashboard <typo3/cms-dashboard:Index>`
 
@@ -83,8 +83,8 @@ part of the Core and extracted at some point in time.
             :button-styles: secondary
 
             :doc:`14-dev <typo3/cms-dashboard/dev:Index>`
-            :doc:`13.4 <typo3/cms-dashboard:Index>`
-            :doc:`12.4 <typo3/cms-dashboard/oldstable:Index>`
+            :doc:`13.4 <typo3/cms-dashboard/13:Index>`
+            :doc:`12.4 <typo3/cms-dashboard/12:Index>`
 
     ..  card:: :doc:`Frontend Login <typo3/cms-felogin:Index>`
 
@@ -96,8 +96,8 @@ part of the Core and extracted at some point in time.
             :button-styles: secondary
 
             :doc:`14-dev <typo3/cms-felogin/dev:Index>`
-            :doc:`13.4 <typo3/cms-felogin:Index>`
-            :doc:`12.4 <typo3/cms-felogin/oldstable:Index>`
+            :doc:`13.4 <typo3/cms-felogin/13:Index>`
+            :doc:`12.4 <typo3/cms-felogin/12:Index>`
 
 
     ..  card:: :doc:`Fluid Styled Content <typo3/cms-fluid-styled-content:Index>`
@@ -110,8 +110,8 @@ part of the Core and extracted at some point in time.
             :button-styles: secondary
 
             :doc:`14-dev <typo3/cms-fluid-styled-content/dev:Index>`
-            :doc:`13.4 <typo3/cms-fluid-styled-content:Index>`
-            :doc:`12.4 <typo3/cms-fluid-styled-content/oldstable:Index>`
+            :doc:`13.4 <typo3/cms-fluid-styled-content/13:Index>`
+            :doc:`12.4 <typo3/cms-fluid-styled-content/12:Index>`
 
     ..  card:: :doc:`Form framework <typo3/cms-form:Index>`
 
@@ -123,8 +123,8 @@ part of the Core and extracted at some point in time.
             :button-styles: secondary
 
             :doc:`14-dev <typo3/cms-form/dev:Index>`
-            :doc:`13.4 <typo3/cms-form:Index>`
-            :doc:`12.4 <typo3/cms-form/oldstable:Index>`
+            :doc:`13.4 <typo3/cms-form/13:Index>`
+            :doc:`12.4 <typo3/cms-form/12:Index>`
 
     ..  card:: :doc:`Indexed Search <typo3/cms-indexed-search:Index>`
 
@@ -137,8 +137,8 @@ part of the Core and extracted at some point in time.
             :button-styles: secondary
 
             :doc:`14-dev <typo3/cms-indexed-search/dev:Index>`
-            :doc:`13.4 <typo3/cms-indexed-search:Index>`
-            :doc:`12.4 <typo3/cms-indexed-search/oldstable:Index>`
+            :doc:`13.4 <typo3/cms-indexed-search/13:Index>`
+            :doc:`12.4 <typo3/cms-indexed-search/12:Index>`
 
     ..  card:: :doc:`Import / Export <typo3/cms-impexp:Index>`
 
@@ -151,8 +151,8 @@ part of the Core and extracted at some point in time.
             :button-styles: secondary
 
             :doc:`14-dev <typo3/cms-impexp/dev:Index>`
-            :doc:`13.4 <typo3/cms-impexp:Index>`
-            :doc:`12.4 <typo3/cms-impexp/oldstable:Index>`
+            :doc:`13.4 <typo3/cms-impexp/13:Index>`
+            :doc:`12.4 <typo3/cms-impexp/12:Index>`
 
     ..  card:: :doc:`Link Validator <typo3/cms-linkvalidator:Index>`
 
@@ -164,8 +164,8 @@ part of the Core and extracted at some point in time.
             :button-styles: secondary
 
             :doc:`14-dev <typo3/cms-linkvalidator/dev:Index>`
-            :doc:`13.4 <typo3/cms-linkvalidator:Index>`
-            :doc:`12.4 <typo3/cms-linkvalidator/oldstable:Index>`
+            :doc:`13.4 <typo3/cms-linkvalidator/13:Index>`
+            :doc:`12.4 <typo3/cms-linkvalidator/12:Index>`
 
     ..  card:: :doc:`Lowlevel <typo3/cms-lowlevel:Index>`
 
@@ -178,8 +178,8 @@ part of the Core and extracted at some point in time.
             :button-styles: secondary
 
             :doc:`14-dev <typo3/cms-lowlevel/dev:Index>`
-            :doc:`13.4 <typo3/cms-lowlevel:Index>`
-            :doc:`12.4 <typo3/cms-lowlevel/oldstable:Index>`
+            :doc:`13.4 <typo3/cms-lowlevel/13:Index>`
+            :doc:`12.4 <typo3/cms-lowlevel/12:Index>`
 
     ..  card:: :doc:`Reactions <typo3/cms-reactions:Index>`
 
@@ -191,7 +191,7 @@ part of the Core and extracted at some point in time.
             :button-styles: secondary
 
             :doc:`14-dev <typo3/cms-reactions/dev:Index>`
-            :doc:`13.4 <typo3/cms-reactions:Index>`
+            :doc:`13.4 <typo3/cms-reactions/13:Index>`
 
     ..  card:: :doc:`Recycler <typo3/cms-recycler:Index>`
 

--- a/Documentation/Home/SystemExtensions.rst
+++ b/Documentation/Home/SystemExtensions.rst
@@ -203,8 +203,8 @@ part of the Core and extracted at some point in time.
             :button-styles: secondary
 
             :doc:`14-dev <typo3/cms-recycler/dev:Index>`
-            :doc:`13.4 <typo3/cms-recycler:Index>`
-            :doc:`12.4 <typo3/cms-recycler/oldstable:Index>`
+            :doc:`13.4 <typo3/cms-recycler/13:Index>`
+            :doc:`12.4 <typo3/cms-recycler/12:Index>`
 
     ..  card:: :doc:`Redirects <typo3/cms-redirects:Index>`
 
@@ -216,8 +216,8 @@ part of the Core and extracted at some point in time.
             :button-styles: secondary
 
             :doc:`14-dev <typo3/cms-redirects/dev:Index>`
-            :doc:`13.4 <typo3/cms-redirects:Index>`
-            :doc:`12.4 <typo3/cms-redirects/oldstable:Index>`
+            :doc:`13.4 <typo3/cms-redirects/13:Index>`
+            :doc:`12.4 <typo3/cms-redirects/12:Index>`
 
     ..  card:: :doc:`Reports <typo3/cms-reports:Index>`
 
@@ -230,7 +230,7 @@ part of the Core and extracted at some point in time.
             :button-styles: secondary
 
             :doc:`14-dev <typo3/cms-reports/dev:Index>`
-            :doc:`13.4 <typo3/cms-reports:Index>`
+            :doc:`13.4 <typo3/cms-reports/13:Index>`
 
     ..  card:: :doc:`CKEditor <typo3/cms-rte-ckeditor:Index>`
 
@@ -242,8 +242,8 @@ part of the Core and extracted at some point in time.
             :button-styles: secondary
 
             :doc:`14-dev <typo3/cms-rte-ckeditor/dev:Index>`
-            :doc:`13.4 <typo3/cms-rte-ckeditor:Index>`
-            :doc:`12.4 <typo3/cms-rte-ckeditor/oldstable:Index>`
+            :doc:`13.4 <typo3/cms-rte-ckeditor/13:Index>`
+            :doc:`12.4 <typo3/cms-rte-ckeditor/12:Index>`
 
     ..  card:: :doc:`Scheduler <typo3/cms-scheduler:Index>`
 
@@ -255,8 +255,8 @@ part of the Core and extracted at some point in time.
             :button-styles: secondary
 
             :doc:`14-dev <typo3/cms-scheduler/dev:Index>`
-            :doc:`13.4 <typo3/cms-scheduler:Index>`
-            :doc:`12.4 <typo3/cms-scheduler/oldstable:Index>`
+            :doc:`13.4 <typo3/cms-scheduler/13:Index>`
+            :doc:`12.4 <typo3/cms-scheduler/12:Index>`
 
     ..  card:: :doc:`SEO <typo3/cms-seo:Index>`
 
@@ -268,8 +268,8 @@ part of the Core and extracted at some point in time.
             :button-styles: secondary
 
             :doc:`14-dev <typo3/cms-seo/dev:Index>`
-            :doc:`13.4 <typo3/cms-seo:Index>`
-            :doc:`12.4 <typo3/cms-seo/oldstable:Index>`
+            :doc:`13.4 <typo3/cms-seo/13:Index>`
+            :doc:`12.4 <typo3/cms-seo/12:Index>`
 
     ..  card:: :doc:`System Notes <typo3/cms-sys-note:Index>`
 
@@ -296,8 +296,8 @@ part of the Core and extracted at some point in time.
             :button-styles: secondary
 
             :doc:`14-dev <typo3/cms-t3editor/dev:Index>`
-            :doc:`13.4 <typo3/cms-t3editor:Index>`
-            :doc:`12.4 <typo3/cms-t3editor/oldstable:Index>`
+            :doc:`13.4 <typo3/cms-t3editor/13:Index>`
+            :doc:`12.4 <typo3/cms-t3editor/12:Index>`
 
     ..  card:: :doc:`Workspaces and Versioning <typo3/cms-workspaces:Index>`
 
@@ -309,8 +309,8 @@ part of the Core and extracted at some point in time.
             :button-styles: secondary
 
             :doc:`14-dev <typo3/cms-workspaces/dev:Index>`
-            :doc:`13.4 <typo3/cms-workspaces:Index>`
-            :doc:`12.4 <typo3/cms-workspaces/oldstable:Index>`
+            :doc:`13.4 <typo3/cms-workspaces/13:Index>`
+            :doc:`12.4 <typo3/cms-workspaces/12:Index>`
 
 .. _System-Extensions-outdated:
 

--- a/Documentation/Home/Templating.rst
+++ b/Documentation/Home/Templating.rst
@@ -23,8 +23,8 @@ Templating
             :button-styles: secondary
 
             :ref:`14-dev <t3coreapi/dev:fluid>`
-            :ref:`13.4 <t3coreapi:fluid>`
-            :ref:`12.4 <t3coreapi/oldstable:fluid>`
+            :ref:`13.4 <t3coreapi/13:fluid>`
+            :ref:`12.4 <t3coreapi/12:fluid>`
 
     ..  card:: :ref:`Sitepackages <t3sitepackage:start>`
 
@@ -35,8 +35,8 @@ Templating
             :button-styles: secondary
 
             :ref:`14-dev <t3sitepackage/dev:start>`
-            :ref:`13.4 <t3sitepackage:start>`
-            :ref:`12.4 <t3sitepackage/oldstable:start>`
+            :ref:`13.4 <t3sitepackage/13:start>`
+            :ref:`12.4 <t3sitepackage/12:start>`
 
 ..  toctree::
     :hidden:

--- a/Documentation/Home/Templating.rst
+++ b/Documentation/Home/Templating.rst
@@ -22,9 +22,9 @@ Templating
         ..  card-footer::
             :button-styles: secondary
 
-            :ref:`13-dev <t3coreapi/dev:fluid>`
-            :ref:`12.4 <t3coreapi:fluid>`
-            :ref:`11.5 <t3coreapi/oldstable:fluid>`
+            :ref:`14-dev <t3coreapi/dev:fluid>`
+            :ref:`13.4 <t3coreapi:fluid>`
+            :ref:`12.4 <t3coreapi/oldstable:fluid>`
 
     ..  card:: :ref:`Sitepackages <t3sitepackage:start>`
 
@@ -34,12 +34,12 @@ Templating
         ..  card-footer::
             :button-styles: secondary
 
-            :ref:`13-dev <t3sitepackage/dev:start>`
-            :ref:`12.4 <t3sitepackage:start>`
-            :ref:`11.5 <t3sitepackage/oldstable:start>`
+            :ref:`14-dev <t3sitepackage/dev:start>`
+            :ref:`13.4 <t3sitepackage:start>`
+            :ref:`12.4 <t3sitepackage/oldstable:start>`
 
 ..  toctree::
     :hidden:
 
-    Templating With Fluid <https://docs.typo3.org/m/typo3/reference-coreapi/12.4/en-us/ApiOverview/Fluid/Index.html>
-    Sitepackages <https://docs.typo3.org/m/typo3/tutorial-sitepackage/12.4/en-us/>
+    Templating With Fluid <https://docs.typo3.org/m/typo3/reference-coreapi/13.4/en-us/ApiOverview/Fluid/Index.html>
+    Sitepackages <https://docs.typo3.org/m/typo3/tutorial-sitepackage/13.4/en-us/>

--- a/Documentation/Home/UpgradingTYPO3.rst
+++ b/Documentation/Home/UpgradingTYPO3.rst
@@ -23,8 +23,8 @@ Upgrading TYPO3
             :button-styles: secondary
 
             :ref:`14-dev <t3upgrade/dev:minor>`
-            :ref:`13.4 <t3upgrade:minor>`
-            :ref:`12.4 <t3upgrade/oldstable:minor>`
+            :ref:`13.4 <t3upgrade/13:minor>`
+            :ref:`12.4 <t3upgrade/12:minor>`
 
     ..  card:: :ref:`Major upgrades <t3upgrade:major>`
 
@@ -37,8 +37,8 @@ Upgrading TYPO3
             :button-styles: secondary
 
             :ref:`14-dev <t3upgrade/dev:major>`
-            :ref:`13.4 <t3upgrade:major>`
-            :ref:`12.4 <t3upgrade/oldstable:major>`
+            :ref:`13.4 <t3upgrade/13:major>`
+            :ref:`12.4 <t3upgrade/12:major>`
 
     ..  card:: :ref:`Upgrading extensions <t3upgrade:upgradingextensions>`
 
@@ -49,8 +49,8 @@ Upgrading TYPO3
             :button-styles: secondary
 
             :ref:`14-dev <t3upgrade/dev:upgradingextensions>`
-            :ref:`13.4 <t3upgrade:upgradingextensions>`
-            :ref:`12.4 <t3upgrade/oldstable:upgradingextensions>`
+            :ref:`13.4 <t3upgrade/13:upgradingextensions>`
+            :ref:`12.4 <t3upgrade/12:upgradingextensions>`
 
     ..  card:: :ref:`Third-party tools <t3upgrade:tools>`
 
@@ -61,8 +61,8 @@ Upgrading TYPO3
             :button-styles: secondary
 
             :ref:`14-dev <t3upgrade/dev:tools>`
-            :ref:`13.4 <t3upgrade:tools>`
-            :ref:`12.4 <t3upgrade/oldstable:tools>`
+            :ref:`13.4 <t3upgrade/13:tools>`
+            :ref:`12.4 <t3upgrade/12:tools>`
 
 
     ..  card:: :ref:`Legacy upgrade guide <t3upgrade:legacy>`
@@ -74,8 +74,8 @@ Upgrading TYPO3
             :button-styles: secondary
 
             :ref:`14-dev <t3upgrade/dev:legacy>`
-            :ref:`13.4 <t3upgrade:legacy>`
-            :ref:`12.4 <t3upgrade/oldstable:legacy>`
+            :ref:`13.4 <t3upgrade/13:legacy>`
+            :ref:`12.4 <t3upgrade/12:legacy>`
 
     ..  card:: :ref:`Migrate a TYPO3 installation to Composer <t3upgrade:migratetocomposer>`
 
@@ -86,8 +86,8 @@ Upgrading TYPO3
             :button-styles: secondary
 
             :ref:`14-dev <t3upgrade/dev:migratetocomposer>`
-            :ref:`13.4 <t3upgrade:migratetocomposer>`
-            :ref:`12.4 <t3upgrade/oldstable:migratetocomposer>`
+            :ref:`13.4 <t3upgrade/13:migratetocomposer>`
+            :ref:`12.4 <t3upgrade/12:migratetocomposer>`
 
     ..  card:: :ref:`Migrate content <t3upgrade:migratecontent>`
 

--- a/Documentation/Home/UpgradingTYPO3.rst
+++ b/Documentation/Home/UpgradingTYPO3.rst
@@ -98,8 +98,8 @@ Upgrading TYPO3
             :button-styles: secondary
 
             :ref:`14-dev <t3upgrade/dev:migratecontent>`
-            :ref:`13.4 <t3upgrade:migratecontent>`
-            :ref:`12.4 <t3upgrade/oldstable:migratecontent>`
+            :ref:`13.4 <t3upgrade/13:migratecontent>`
+            :ref:`12.4 <t3upgrade/12:migratecontent>`
 
 
 ..  toctree::

--- a/Documentation/Home/UpgradingTYPO3.rst
+++ b/Documentation/Home/UpgradingTYPO3.rst
@@ -14,7 +14,7 @@ Upgrading TYPO3
 
     ..  card:: :ref:`Minor upgrades <t3upgrade:minor>`
 
-        Minor updates (for example 12.4.1 to 12.4.2)
+        Minor updates (for example 13.4.1 to 13.4.2)
         contain bugfixes and/or security updates.
         This chapter details how updates are installed and highlights what tasks need to
         be carried out before and after the core is updated.
@@ -22,13 +22,13 @@ Upgrading TYPO3
         ..  card-footer::
             :button-styles: secondary
 
-            :ref:`13-dev <t3upgrade/dev:minor>`
-            :ref:`12.4 <t3upgrade:minor>`
-            :ref:`11.5 <t3upgrade/oldstable:minor>`
+            :ref:`14-dev <t3upgrade/dev:minor>`
+            :ref:`13.4 <t3upgrade:minor>`
+            :ref:`12.4 <t3upgrade/oldstable:minor>`
 
     ..  card:: :ref:`Major upgrades <t3upgrade:major>`
 
-        Major updates (for example 11.5 to 12.4) can contain new features
+        Major updates (for example 12.4 to 13.4) can contain new features
         and breaking changes as well as bugfixes.
         This chapter details how updates are installed and highlights what tasks need to
         be carried out before and after the core is updated.
@@ -36,9 +36,9 @@ Upgrading TYPO3
         ..  card-footer::
             :button-styles: secondary
 
-            :ref:`13-dev <t3upgrade/dev:major>`
-            :ref:`12.4 <t3upgrade:major>`
-            :ref:`11.5 <t3upgrade/oldstable:major>`
+            :ref:`14-dev <t3upgrade/dev:major>`
+            :ref:`13.4 <t3upgrade:major>`
+            :ref:`12.4 <t3upgrade/oldstable:major>`
 
     ..  card:: :ref:`Upgrading extensions <t3upgrade:upgradingextensions>`
 
@@ -48,9 +48,9 @@ Upgrading TYPO3
         ..  card-footer::
             :button-styles: secondary
 
-            :ref:`13-dev <t3upgrade/dev:upgradingextensions>`
-            :ref:`12.4 <t3upgrade:upgradingextensions>`
-            :ref:`11.5 <t3upgrade/oldstable:upgradingextensions>`
+            :ref:`14-dev <t3upgrade/dev:upgradingextensions>`
+            :ref:`13.4 <t3upgrade:upgradingextensions>`
+            :ref:`12.4 <t3upgrade/oldstable:upgradingextensions>`
 
     ..  card:: :ref:`Third-party tools <t3upgrade:tools>`
 
@@ -60,9 +60,9 @@ Upgrading TYPO3
         ..  card-footer::
             :button-styles: secondary
 
-            :ref:`13-dev <t3upgrade/dev:tools>`
-            :ref:`12.4 <t3upgrade:tools>`
-            :ref:`11.5 <t3upgrade/oldstable:tools>`
+            :ref:`14-dev <t3upgrade/dev:tools>`
+            :ref:`13.4 <t3upgrade:tools>`
+            :ref:`12.4 <t3upgrade/oldstable:tools>`
 
 
     ..  card:: :ref:`Legacy upgrade guide <t3upgrade:legacy>`
@@ -73,9 +73,9 @@ Upgrading TYPO3
         ..  card-footer::
             :button-styles: secondary
 
-            :ref:`13-dev <t3upgrade/dev:legacy>`
-            :ref:`12.4 <t3upgrade:legacy>`
-            :ref:`11.5 <t3upgrade/oldstable:legacy>`
+            :ref:`14-dev <t3upgrade/dev:legacy>`
+            :ref:`13.4 <t3upgrade:legacy>`
+            :ref:`12.4 <t3upgrade/oldstable:legacy>`
 
     ..  card:: :ref:`Migrate a TYPO3 installation to Composer <t3upgrade:migratetocomposer>`
 
@@ -85,9 +85,9 @@ Upgrading TYPO3
         ..  card-footer::
             :button-styles: secondary
 
-            :ref:`13-dev <t3upgrade/dev:migratetocomposer>`
-            :ref:`12.4 <t3upgrade:migratetocomposer>`
-            :ref:`11.5 <t3upgrade/oldstable:migratetocomposer>`
+            :ref:`14-dev <t3upgrade/dev:migratetocomposer>`
+            :ref:`13.4 <t3upgrade:migratetocomposer>`
+            :ref:`12.4 <t3upgrade/oldstable:migratetocomposer>`
 
     ..  card:: :ref:`Migrate content <t3upgrade:migratecontent>`
 
@@ -97,18 +97,18 @@ Upgrading TYPO3
         ..  card-footer::
             :button-styles: secondary
 
-            :ref:`13-dev <t3upgrade/dev:migratecontent>`
-            :ref:`12.4 <t3upgrade:migratecontent>`
-            :ref:`11.5 <t3upgrade/oldstable:migratecontent>`
+            :ref:`14-dev <t3upgrade/dev:migratecontent>`
+            :ref:`13.4 <t3upgrade:migratecontent>`
+            :ref:`12.4 <t3upgrade/oldstable:migratecontent>`
 
 
 ..  toctree::
     :hidden:
 
-    Minor upgrades <https://docs.typo3.org/m/typo3/guide-installation/12.4/en-us/Minor/Index.html>
-    Major upgrades <https://docs.typo3.org/m/typo3/guide-installation/12.4/en-us/Major/Index.html>
-    Upgrading extensions <https://docs.typo3.org/m/typo3/guide-installation/12.4/en-us/UpgradingExtensions>
-    Third-party tools <https://docs.typo3.org/m/typo3/guide-installation/12.4/en-us/Tools/Index.html>
-    Legacy upgrade <https://docs.typo3.org/m/typo3/guide-installation/12.4/en-us/Legacy/Index.html>
-    Migrate to Composer <https://docs.typo3.org/m/typo3/guide-installation/12.4/en-us/MigrateToComposer/Index.html>
-    Migrate content <https://docs.typo3.org/m/typo3/guide-installation/12.4/en-us/MigrateContent/Index.html>
+    Minor upgrades <https://docs.typo3.org/m/typo3/guide-installation/13.4/en-us/Minor/Index.html>
+    Major upgrades <https://docs.typo3.org/m/typo3/guide-installation/13.4/en-us/Major/Index.html>
+    Upgrading extensions <https://docs.typo3.org/m/typo3/guide-installation/13.4/en-us/UpgradingExtensions>
+    Third-party tools <https://docs.typo3.org/m/typo3/guide-installation/13.4/en-us/Tools/Index.html>
+    Legacy upgrade <https://docs.typo3.org/m/typo3/guide-installation/13.4/en-us/Legacy/Index.html>
+    Migrate to Composer <https://docs.typo3.org/m/typo3/guide-installation/13.4/en-us/MigrateToComposer/Index.html>
+    Migrate content <https://docs.typo3.org/m/typo3/guide-installation/13.4/en-us/MigrateContent/Index.html>

--- a/Documentation/Home/_OverviewInclude.rst.txt
+++ b/Documentation/Home/_OverviewInclude.rst.txt
@@ -21,7 +21,7 @@ Getting Started with TYPO3
         *  :ref:`Installation Guide <t3start:installation_index>` details
            the entire installation process.
 
-        *  :ref:`Setup Guide <t3start:setup>` guides you through the next steps
+        *  :ref:`Setup Guide <t3start:first-project-setup>` guides you through the next steps
            post installation.
 
     ..  card:: :ref:`Creating & Managing Content <creatingmanagingcontent>`
@@ -33,7 +33,6 @@ Getting Started with TYPO3
 
         *  :ref:`Localization Guide <t3l10n:start>` covers everything needed to add additional languages to a
            TYPO3 site, and how to translate content and pages.
-
 
     ..  card:: :ref:`Templating & Sitepackages <templating>`
 

--- a/Documentation/guides.xml
+++ b/Documentation/guides.xml
@@ -17,8 +17,6 @@
              version="2.0"
              copyright="since 2014 by the TYPO3 contributors"/>
     <inventory id="t3coreapimain" url="https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/"/>
-    <inventory id="t3coreapi12" url="https://docs.typo3.org/m/typo3/reference-coreapi/12.4/en-us/"/>
-    <inventory id="t3coreapi11" url="https://docs.typo3.org/m/typo3/reference-coreapi/11.5/en-us/"/>
     <inventory id="t3l10n" url="https://docs.typo3.org/m/typo3/guide-frontendlocalization/12.4/en-us/"/>
     <inventory id="t3upgrade" url="https://docs.typo3.org/m/typo3/guide-installation/12.4/en-us/"/>
     <inventory id="ext_core" url="https://docs.typo3.org/c/typo3/cms-core/main/en-us/"/>

--- a/Documentation/mainMenu.rst.txt
+++ b/Documentation/mainMenu.rst.txt
@@ -5,32 +5,32 @@
     *   :ref:`TYPO3 Explained <t3coreapi:start>`
 
         *   :ref:`main <t3coreapi/main:start>`
+        *   :ref:`13.4 <t3coreapi/13:start>`
         *   :ref:`12.4 <t3coreapi/12:start>`
-        *   :ref:`11.5 <t3coreapi/11:start>`
 
     *   :ref:`Fluid ViewHelper Reference <t3viewhelper:start>`
 
         *   :ref:`main <t3viewhelper/main:start>`
+        *   :ref:`13.4 <t3viewhelper/13:start>`
         *   :ref:`12.4 <t3viewhelper/12:start>`
-        *   :ref:`11.5 <t3viewhelper/11:start>`
 
     *   :ref:`TCA Reference <t3tca:start>`
 
         *   :ref:`main <t3tca/main:start>`
+        *   :ref:`13.4 <t3tca/13:start>`
         *   :ref:`12.4 <t3tca/12:start>`
-        *   :ref:`11.5 <t3tca/11:start>`
 
     *   :ref:`TSconfig Reference <t3tsconfig:start>`
 
         *   :ref:`main <t3tsconfig/main:start>`
+        *   :ref:`13.4 <t3tsconfig/13:start>`
         *   :ref:`12.4 <t3tsconfig/12:start>`
-        *   :ref:`11.5 <t3tsconfig/11:start>`
 
     *   :ref:`TypoScript Reference <t3tsref:start>`
 
         *   :ref:`main <t3tsref/main:start>`
+        *   :ref:`13.4 <t3tsref/13:start>`
         *   :ref:`12.4 <t3tsref/12:start>`
-        *   :ref:`11.5 <t3tsref/11:start>`
 
     *   :ref:`TYPO3 Exceptions <t3exceptions:start>`
 
@@ -39,34 +39,34 @@
     *   :ref:`TYPO3 - Getting Started Tutorial <t3start:start>`
 
         *   :ref:`main <t3start/main:start>`
+        *   :ref:`13.4 <t3start/13:start>`
         *   :ref:`12.4 <t3start/12:start>`
-        *   :ref:`11.5 <t3start/11:start>`
 
     *   :ref:`TYPO3 Editors Guide <t3editors:start>`
 
         *   :ref:`main <t3editors/main:start>`
+        *   :ref:`13.4 <t3editors/13:start>`
         *   :ref:`12.4 <t3editors/12:start>`
-        *   :ref:`11.5 <t3editors/11:start>`
 
     *   :ref:`Frontend Localization Guide <t3translate:start>`
 
         *   :ref:`main <t3translate/main:start>`
+        *   :ref:`13.4 <t3translate/12:start>`
         *   :ref:`12.4 <t3translate/12:start>`
-        *   :ref:`11.5 <t3translate/11:start>`
 
     *   :ref:`TYPO3 Upgrade Guide <t3upgrade:start>`
 
         *   :ref:`main <t3upgrade/main:start>`
+        *   :ref:`13.4 <t3upgrade/13:start>`
         *   :ref:`12.4 <t3upgrade/12:start>`
-        *   :ref:`11.5 <t3upgrade/11:start>`
 
 *   :ref:`Tutorials <t3docs:references>`
 
     *   :ref:`TYPO3 Sitepackage Tutorial <t3sitepackage:start>`
 
         *   :ref:`main <t3sitepackage/main:start>`
+        *   :ref:`13.4 <t3sitepackage/13:start>`
         *   :ref:`12.4 <t3sitepackage/12:start>`
-        *   :ref:`11.5 <t3sitepackage/11:start>`
 
 *   :ref:`Contribution <t3docs:contribute>`
 
@@ -81,112 +81,115 @@
     *   :doc:`adminpanel <typo3/cms-adminpanel:Index>`
 
         *   :doc:`main <typo3/cms-adminpanel/main:Index>`
+        *   :doc:`13.4 <typo3/cms-adminpanel/13:Index>`
         *   :doc:`12.4 <typo3/cms-adminpanel/12:Index>`
-        *   :doc:`11.5 <typo3/cms-adminpanel/11:Index>`
 
     *   :doc:`dashboard <typo3/cms-dashboard:Index>`
 
         *   :doc:`main <typo3/cms-dashboard/main:Index>`
+        *   :doc:`13.4 <typo3/cms-dashboard/13:Index>`
         *   :doc:`12.4 <typo3/cms-dashboard/12:Index>`
-        *   :doc:`11.5 <typo3/cms-dashboard/11:Index>`
 
     *   :doc:`felogin <typo3/cms-felogin:Index>`
 
         *   :doc:`main <typo3/cms-felogin/main:Index>`
+        *   :doc:`13.4 <typo3/cms-felogin/13:Index>`
         *   :doc:`12.4 <typo3/cms-felogin/12:Index>`
-        *   :doc:`11.5 <typo3/cms-felogin/11:Index>`
 
     *   :doc:`fluid_styled_content <typo3/cms-fluid-styled-content:Index>`
 
         *   :doc:`main <typo3/cms-fluid-styled-content/main:Index>`
+        *   :doc:`13.4 <typo3/cms-fluid-styled-content/13:Index>`
         *   :doc:`12.4 <typo3/cms-fluid-styled-content/12:Index>`
-        *   :doc:`11.5 <typo3/cms-fluid-styled-content/11:Index>`
 
     *   :doc:`form <typo3/cms-form:Index>`
 
         *   :doc:`main <typo3/cms-form/main:Index>`
+        *   :doc:`13.4 <typo3/cms-form/13:Index>`
         *   :doc:`12.4 <typo3/cms-form/12:Index>`
-        *   :doc:`11.5 <typo3/cms-form/11:Index>`
 
     *   :doc:`impexp <typo3/cms-impexp:Index>`
 
         *   :doc:`main <typo3/cms-impexp/main:Index>`
+        *   :doc:`13.4 <typo3/cms-impexp/13:Index>`
         *   :doc:`12.4 <typo3/cms-impexp/12:Index>`
-        *   :doc:`11.5 <typo3/cms-impexp/11:Index>`
 
     *   :doc:`indexed_search <typo3/cms-indexed-search:Index>`
 
         *   :doc:`main <typo3/cms-indexed-search/main:Index>`
+        *   :doc:`13.4 <typo3/cms-indexed-search/13:Index>`
         *   :doc:`12.4 <typo3/cms-indexed-search/12:Index>`
-        *   :doc:`11.5 <typo3/cms-indexed-search/11:Index>`
 
     *   :doc:`linkvalidator <typo3/cms-linkvalidator:Index>`
 
         *   :doc:`main <typo3/cms-linkvalidator/main:Index>`
+        *   :doc:`13.4 <typo3/cms-linkvalidator/13:Index>`
         *   :doc:`12.4 <typo3/cms-linkvalidator/12:Index>`
-        *   :doc:`11.5 <typo3/cms-linkvalidator/11:Index>`
 
     *   :doc:`lowlevel <typo3/cms-lowlevel:Index>`
 
         *   :doc:`main <typo3/cms-lowlevel/main:Index>`
+        *   :doc:`13.4 <typo3/cms-lowlevel/13:Index>`
         *   :doc:`12.4 <typo3/cms-lowlevel/12:Index>`
-        *   :doc:`11.5 <typo3/cms-lowlevel/11:Index>`
 
 *   :ref:`System Extensions R-Z <t3docs:System-Extensions>`
 
     *   :doc:`reactions <typo3/cms-reactions:Index>`
 
         *   :doc:`main <typo3/cms-reactions/main:Index>`
+        *   :doc:`13.4 <typo3/cms-reactions/13:Index>`
         *   :doc:`12.4 <typo3/cms-reactions/12:Index>`
 
     *   :doc:`recycler <typo3/cms-recycler:Index>`
 
         *   :doc:`main <typo3/cms-recycler/main:Index>`
+        *   :doc:`13.4 <typo3/cms-recycler/13:Index>`
         *   :doc:`12.4 <typo3/cms-recycler/12:Index>`
-        *   :doc:`11.5 <typo3/cms-recycler/11:Index>`
 
     *   :doc:`redirects <typo3/cms-redirects:Index>`
 
         *   :doc:`main <typo3/cms-redirects/main:Index>`
+        *   :doc:`13.4 <typo3/cms-redirects/13:Index>`
         *   :doc:`12.4 <typo3/cms-redirects/12:Index>`
-        *   :doc:`11.5 <typo3/cms-redirects/11:Index>`
 
     *   :doc:`reports <typo3/cms-reports:Index>`
 
         *   :doc:`main <typo3/cms-reports/main:Index>`
+        *   :doc:`13.4 <typo3/cms-reports/13:Index>`
         *   :doc:`12.4 <typo3/cms-reports/12:Index>`
 
     *   :doc:`rte_ckeditor <typo3/cms-rte-ckeditor:Index>`
 
         *   :doc:`main <typo3/cms-rte-ckeditor/main:Index>`
+        *   :doc:`13.4 <typo3/cms-rte-ckeditor/13:Index>`
         *   :doc:`12.4 <typo3/cms-rte-ckeditor/12:Index>`
-        *   :doc:`11.5 <typo3/cms-rte-ckeditor/11:Index>`
 
     *   :doc:`scheduler <typo3/cms-scheduler:Index>`
 
         *   :doc:`main <typo3/cms-scheduler/main:Index>`
+        *   :doc:`13.4 <typo3/cms-scheduler/13:Index>`
         *   :doc:`12.4 <typo3/cms-scheduler/12:Index>`
-        *   :doc:`11.5 <typo3/cms-scheduler/11:Index>`
 
     *   :doc:`seo <typo3/cms-seo:Index>`
 
         *   :doc:`main <typo3/cms-seo/main:Index>`
+        *   :doc:`13.4 <typo3/cms-seo/13:Index>`
         *   :doc:`12.4 <typo3/cms-seo/12:Index>`
-        *   :doc:`11.5 <typo3/cms-seo/11:Index>`
 
     *   :doc:`sys_note <typo3/cms-sys-note:Index>`
 
         *   :doc:`main <typo3/cms-sys-note/main:Index>`
+        *   :doc:`13.4 <typo3/cms-sys-note/13:Index>`
         *   :doc:`12.4 <typo3/cms-sys-note/12:Index>`
 
     *   :doc:`t3editor <typo3/cms-t3editor:Index>`
 
         *   :doc:`main <typo3/cms-t3editor/main:Index>`
+        *   :doc:`13.4 <typo3/cms-t3editor/13:Index>`
         *   :doc:`12.4 <typo3/cms-t3editor/12:Index>`
-        *   :doc:`11.5 <typo3/cms-t3editor/11:Index>`
 
     *   :doc:`workspaces <typo3/cms-workspaces:Index>`
 
         *   :doc:`main <typo3/cms-workspaces/main:Index>`
+        *   :doc:`13.4 <typo3/cms-workspaces/13:Index>`
         *   :doc:`12.4 <typo3/cms-workspaces/12:Index>`
-        *   :doc:`11.5 <typo3/cms-workspaces/11:Index>`


### PR DESCRIPTION
The links to 13 will automatically be changed to 13.4 branches once TYPO3 13.4.0 is released and the links are changed in the render-guides. Until then the point to main