### PR TITLE
Enhance robots.txt to support AI crawlers with equal access to TYPO3 …

### DIFF
--- a/WebRootResources/robots.txt
+++ b/WebRootResources/robots.txt
@@ -1,12 +1,72 @@
+# =============================================
+# General search engine rules
+# =============================================
 User-agent: *
-# @TODO: still required?
 Disallow: /getthedocs/files/
-
-# Dont' index the services folder
 Disallow: /services/
-
-# Don't index drafts
+Disallow: /search/*
 Disallow: */draft/*
-
-# Don't index singlehtml versions of docs to avoid duplicate content
 Disallow: */singlehtml/*
+
+# =============================================
+# AI-specific access rules for large language models
+# Equal access for all major AI bots
+# =============================================
+
+User-agent: GPTBot
+User-agent: ClaudeBot
+User-agent: Google-Extended
+User-agent: CCBot
+User-agent: PerplexityBot
+User-agent: AppleBot
+User-agent: PhindBot
+User-agent: YouBot
+User-agent: facebookexternalhit
+
+# TYPO3 Core manuals (LTS, eLTS, dev)
+Allow: /m/typo3/*/13.4/en-us/
+Allow: /m/typo3/*/13.4/en-us/singlehtml/
+Allow: /m/typo3/*/12.4/en-us/
+Allow: /m/typo3/*/12.4/en-us/singlehtml/
+Allow: /m/typo3/*/11.5/en-us/
+Allow: /m/typo3/*/11.5/en-us/singlehtml/
+Allow: /m/typo3/*/10.4/en-us/
+Allow: /m/typo3/*/10.4/en-us/singlehtml/
+Allow: /m/typo3/*/main/en-us/
+Allow: /m/typo3/*/main/en-us/singlehtml/
+
+# System extensions
+Allow: /c/typo3/*/13.4/en-us/
+Allow: /c/typo3/*/13.4/en-us/singlehtml/
+Allow: /c/typo3/*/12.4/en-us/
+Allow: /c/typo3/*/12.4/en-us/singlehtml/
+Allow: /c/typo3/*/main/en-us/
+Allow: /c/typo3/*/main/en-us/singlehtml/
+
+# Official TYPO3 libraries (e.g. Fluid)
+Allow: /other/typo3fluid/*/main/en-us/
+Allow: /other/typo3fluid/*/main/en-us/singlehtml/
+Allow: /other/typo3fluid/*/2.*/en-us/
+Allow: /other/typo3fluid/*/2.*/en-us/singlehtml/
+
+# Other official manuals
+Allow: /other/typo3/*/13.4/en-us/
+Allow: /other/typo3/*/13.4/en-us/singlehtml/
+Allow: /other/typo3/*/12.4/en-us/
+Allow: /other/typo3/*/12.4/en-us/singlehtml/
+Allow: /other/typo3/*/main/en-us/
+Allow: /other/typo3/*/main/en-us/singlehtml/
+
+# Third-party extensions
+Allow: /p/*/*/main/en-us/
+Allow: /p/*/*/main/en-us/singlehtml/
+Allow: /p/*/*/10.*/en-us/
+Allow: /p/*/*/10.*/en-us/singlehtml/
+Allow: /p/*/*/11.*/en-us/
+Allow: /p/*/*/11.*/en-us/singlehtml/
+
+# Disallow internal or irrelevant areas
+Disallow: /search/
+Disallow: /services/
+Disallow: /getthedocs/files/
+Disallow: */draft/*


### PR DESCRIPTION
…docs

- Grants GPTBot, ClaudeBot, Google-Extended, CCBot, PerplexityBot, and others access to relevant TYPO3 documentation content
- Allows core, system extension, library, and popular third-party manuals for LTS, eLTS, and development versions
- Keeps general search engine rules unchanged
- Uses unified rules for AI bots to ensure fairness and easier maintenance