### PR TITLE
[TASK] Add usermapping for linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,11 +8,11 @@ help: ## Displays this list of targets with descriptions
 docs: ## Generate projects docs (from "Documentation" directory)
 	mkdir -p Documentation-GENERATED-temp
 
-	docker run --rm --pull always -v "$(shell pwd)":/project -t ghcr.io/typo3-documentation/render-guides:latest --config=Documentation
+	docker run --user $(shell id -u):$(shell id -g) --rm --pull always -v "$(shell pwd)":/project -t ghcr.io/typo3-documentation/render-guides:latest --config=Documentation
 
 .PHONY: test-docs
 test-docs: ## Test the documentation rendering
 	mkdir -p Documentation-GENERATED-temp
 
-	docker run --rm --pull always -v "$(shell pwd)":/project -t ghcr.io/typo3-documentation/render-guides:latest --config=Documentation --no-progress --minimal-test
+	docker run --user $(shell id -u):$(shell id -g) --rm --pull always -v "$(shell pwd)":/project -t ghcr.io/typo3-documentation/render-guides:latest --config=Documentation --no-progress --minimal-test
 


### PR DESCRIPTION
This is to prevent this error:
Status: Image is up to date for ghcr.io/typo3-documentation/render-guides:latest
addgroup: gid '100' in use
Error: Failed to add group 'typo3' inside docker container.
